### PR TITLE
Fix duplicate address detection

### DIFF
--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -204,10 +204,10 @@ func (d *DeviceManager) nextClientAddress() (string, error) {
 		startIPv6 := vpnipv6.Mask(vpnsubnetv6.Mask)
 
 		// Add the network address and the VPN server address to the list of occupied addresses
-		usedIPv6s = []net.IP{
+		usedIPv6s = append(usedIPv6s,
 			startIPv6,         // ::0
 			nextIP(startIPv6), // ::1
-		}
+		)
 
 		for ip := startIPv6; vpnsubnetv6.Contains(ip); ip = nextIP(ip) {
 			if !contains(usedIPv6s, ip) {


### PR DESCRIPTION
Das sollte das Problem mit den mehrfach vergebenen IPv6 Adressen lösen.

Anstatt die Gateway- & Netzwerkadressen an das existierende Array mit allen bereits benutzten Adressen anzuhängen wurde es überschreiben, was im Endeffekt dazu führte dass alle Clients die ::2 zugeteilt bekommen.

Fix getestet, sollte funktionieren.