### PR TITLE
Add pull request build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,53 +1,31 @@
-name: Build and push docker images
+name: Build Docker image
 
 on:
   push:
     branches:
-      - 'master'
-    tags:
-      - 'v*.*.*'
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Prepare
-        id: prep
-        run: |
-          TAGS=""
-          IMAGE="place1/wg-access-server"
-
-          if [[ "$GITHUB_REF" == refs/heads/master ]]; then
-            TAGS="$IMAGE:master"
-          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/}"
-            TAGS="$IMAGE:$VERSION"
-            if [[ ! "$VERSION" =~ -rc.* ]]; then
-              TAGS="$TAGS,$IMAGE:latest"
-            fi
-          fi
-
-          echo "building ref: $GITHUB_REF"
-          echo "docker images: $TAGS"
-          echo ::set-output name=tags::${TAGS}
-
       - name: Checkout
         uses: actions/checkout@v2
-
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
-
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          version: latest
-          driver-opts: image=moby/buildkit:v0.9.0
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          context: .
+          platforms: linux/amd64
+          push: false
+          tags: wg-access-server:testing
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Motivation
This repo is currently missing any sort of CI / PR tests.
This means that problems with the changes can only be discovered through manual review (by another person) or after merging it and waiting for the deployment workflow to fail or finish.

It would be preferable to have some automated feedback right away, without having to wait for review or merge.

## Changes
This reworks the currently defunct `build.yaml` workflow file to build the Docker image in pull requests, to give us some basic CI / validation and catch basic errors.

Unfortunately wg-access-server doesn't have any sort of unit testing set up, neither for the JS frontend code nor the Go backend code, so we can only check whether everything builds successfully.

The workflow is similar to the deployment workflow (docker.yml), except it only builds one architecture (amd64) to speed it up, and doesn't push the image.
It also uses the [gha buildx cache](https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache) to speed up future builds