### PR TITLE
Fix mysql connection string

### DIFF
--- a/internal/storage/sql.go
+++ b/internal/storage/sql.go
@@ -92,7 +92,7 @@ func pgconn(u *url.URL) string {
 func mysqlconn(u *url.URL) string {
 	password, _ := u.User.Password()
 	return fmt.Sprintf(
-		"%s:%s@%s/%s?%s",
+		"%s:%s@tcp(%s)/%s?%s",
 		u.User.Username(),
 		password,
 		u.Host,


### PR DESCRIPTION
This is a cherry-pick of https://github.com/Place1/wg-access-server/pull/135 fixing issue https://github.com/Place1/wg-access-server/issues/134

It has been slightly changed from @Nox-404's solution, using `url.Host` instead of `url.Hostname()` and `url.Port()` joined separately, as the second one would cause issues with raw IPv6 addresses (which `url.Hostname()` returns _without_ enclosing brackets). `url.Host` returns host and port already combined, with brackets for IPv6 addresses.