### PR TITLE
Use GitHub cache for building deployment Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,11 @@
 .git/
+.github/
+.vscode/
+docs/
+
+# Common artifacts from building and running locally
+config.yaml
+db.sqlite3
+wg-access-server
 **/node_modules/
 **/build/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,6 +39,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}:latest
           labels: |


### PR DESCRIPTION
## Motivation
Our Docker image builds take around one hour to build and push to the registry:
![build times](https://user-images.githubusercontent.com/28812678/142900345-4cdb4a24-ed6e-4f5c-ad6c-ccfcee382352.png)

We build for three different (emulated) architectures, without any caching, which takes a lot of time.
While pushes usually aren't urgent to publish to the world, there are occasions where you want to make use of newly pushed changes quickly.
Since we also directly push to `:latest`, there is always a race condition between parallel builds. With long running builds there is also an increased risk of overlapping builds, where the newer one finishes first and the older one then overwrites `:latest`.
It's also nice not to burn through CPU cycles if you don't need to.

## Changes
Now we let buildx/BuildKit use the GitHub Action cache, see https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache
This automatically pushes the final and intermediate layers to the cache backend after a successful build, and downloads them before the next build.

The test builds for PRs already do the same.
The feature is still declared as experimental, however neither here nor in other repositories I've encountered any issues with it, so I think that's fine.

While I was on it, I also added a few more entries to `.dockerignore`. I'm honestly not sure whether they'll have any actual effect, as the Dockerfile never copies the entire working directory (`COPY . /whatever`), but it doesn't hurt to have.

Closes #23 