### PR TITLE
Fix DNS proxy upstream lookup loop

### DIFF
--- a/internal/dnsproxy/server.go
+++ b/internal/dnsproxy/server.go
@@ -121,8 +121,10 @@ func (d *DNSServer) Lookup(m *dns.Msg) (*dns.Msg, error) {
 		if err != nil && firstErr == nil {
 			logrus.Warnf(errors.Wrap(err, fmt.Sprintf("DNS lookup failed for upstream %s", upstream)).Error())
 			firstErr = err
+		} else if err == nil {
+			response = resp
+			break
 		}
-		response = resp
 	}
 	if response == nil {
 		return nil, firstErr


### PR DESCRIPTION
The proxy always queried *all* upstream servers and returned the last good response,
instead of returning the first good one.

This resulted both in unnecessary DNS traffic and load on upstream servers,
as well as increased response times.

Now the loop is properly short-circuited when a good response has been found.