### PR TITLE
Always run npm build stage on host-native platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### Build stage for the website frontend
-FROM node:17-bullseye as website
+FROM --platform=$BUILDPLATFORM node:17-bullseye as website
 RUN apt-get update
 RUN apt-get install -y protobuf-compiler libprotobuf-dev
 WORKDIR /code


### PR DESCRIPTION
## Problem
We've encountered the image publish workflow repeatedly failing with network problems, like
```
#110 [linux/arm/v7 website  7/11] RUN npm ci --no-audit --prefer-offline
#110 325.7 npm ERR! code ERR_SOCKET_TIMEOUT
#110 325.7 npm ERR! network Socket timeout
#110 325.7 npm ERR! network This is a problem related to network connectivity.
#110 325.7 npm ERR! network In most cases you are behind a proxy or have bad network settings.
#110 325.8 npm ERR! network 
#110 325.8 npm ERR! network If you are behind a proxy, please make sure that the
#110 325.8 npm ERR! network 'proxy' config is set properly.  See: 'npm help config'
#110 327.1 
#110 327.1 npm ERR! A complete log of this run can be found in:
#110 327.1 npm ERR!     /root/.npm/_logs/2022-01-26T15_26_51_037Z-debug-0.log
#110 ERROR: process "/bin/sh -c npm ci --no-audit --prefer-offline" did not complete successfully: exit code: 1
```

- https://github.com/freifunkMUC/wg-access-server/actions/runs/1750140386
- https://github.com/freifunkMUC/wg-access-server/actions/runs/1744624533
- https://github.com/freifunkMUC/wg-access-server/actions/runs/1740503173

They only seem to happen on the arm builds. Maybe a bug with the buildx QEMU emulation?

## Changes
As I've already mentioned in #76, buildx supports running individual steps on a platform different than the target platform, e.g. the host platform to circumvent the high-overhead userspace emulation.
While this is a bit more involved with binary compilation (see comments and links there), it's less complicated with HTML/JS/CSS files, as the end product is platform-independent.

Now I've added the `--platform=$BUILDPLATFORM` argument to the `FROM` line of the npm build step.
This will run this step on the host "native" platform (not sure if buildx runs it fully without QEMU, in any case it's much faster and less buggy).
This should not only workaround the issue we encountered, but also speed up the builds. If I'm not mistaken, buildx recognizes that the stage is fully target-platform-independent (no `ARG TARGETOS`/`ARG TARGETARCH`) and only run it a single time (instead of once per target arch).

See also
- [Faster Multi-Platform Builds: Dockerfile Cross-Compilation Guide](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/)
- https://docs.docker.com/engine/reference/builder/#from