### PR TITLE
Build and publish ppc64le and s390x images, limit parallel buildx jobs to 4

### DIFF
--- a/.github/buildkitd.toml
+++ b/.github/buildkitd.toml
@@ -1,0 +1,2 @@
+[worker.oci]
+  max-parallelism = 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          config: .github/buildkitd.toml
       - name: Retrieve author data
         run: |
           echo AUTHOR=$(curl -sSL ${{ github.event.repository.owner.url }} | jq -r '.name') >> $GITHUB_ENV

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,8 @@ jobs:
           platforms: all
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          config: .github/buildkitd.toml
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -46,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7,linux/ppc64le,linux/s390x
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,4 @@
-name: tests
+name: Linting
 
 on:
   push:


### PR DESCRIPTION
## Changes
This builds and publishes the Docker image for ppc64le and s390x as requested by @GoliathLabs in #76.

To reduce the effect of the additional architectures on build time (which can cause ugly race conditions where an image of an earlier commit is pushed later as `latest` or `master` than the actually latest commit), the parallel jobs that buildx can run at the same time is now limited to `4` (instead of unlimited), which might or might not reduce context switches and memory consumption.

It did at least show an improvement in my testing of around 20% for completely uncached runs: 
![build times](https://user-images.githubusercontent.com/28812678/151558778-8cb979db-ac6f-46cd-a4a2-bef4b9007c52.png)
(But I can't rule out that this wasn't just caused by the actions running at slightly different times on different runners with different load)

See also: https://github.com/docker/setup-buildx-action#max-parallelism

Closes #76