### PR TITLE
changed the "is connected" time to 3 minutes

### DIFF
--- a/internal/services/device_service.go
+++ b/internal/services/device_service.go
@@ -122,5 +122,5 @@ func isConnected(lastHandshake *time.Time) bool {
 	if lastHandshake == nil {
 		return false
 	}
-	return lastHandshake.After(time.Now().Add(-1 * time.Minute))
+	return lastHandshake.After(time.Now().Add(-3 * time.Minute))
 }


### PR DESCRIPTION
This could be useful if a client's connection is unstable and no handshake has taken place in the last 3 minutes. This is up for debate though.