### PR TITLE
Added: Strong admin password generation to default README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Quick Links:
 Here is a quick command to start the wg-access-server for the first time and try it out.
 
 ```bash
-export WG_ADMIN_PASSWORD=$(pwgen -s 64 1)
+export WG_ADMIN_PASSWORD=$(tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1)
 export WG_WIREGUARD_PRIVATE_KEY="$(wg genkey)"
+echo "Your admin password for the wg-access-server: $WG_ADMIN_PASSWORD"
 
 docker run \
   -it \

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Here is a quick command to start the wg-access-server for the first time and try
 ```bash
 export WG_ADMIN_PASSWORD=$(tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1)
 export WG_WIREGUARD_PRIVATE_KEY="$(wg genkey)"
-echo "Your admin password for the wg-access-server: $WG_ADMIN_PASSWORD"
+echo "Your automatically generated admin password for the wg-access-server's web interface: $WG_ADMIN_PASSWORD"
 
 docker run \
   -it \

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Quick Links:
 Here is a quick command to start the wg-access-server for the first time and try it out.
 
 ```bash
-export WG_ADMIN_PASSWORD="example"
+export WG_ADMIN_PASSWORD=$(pwgen -s 64 1)
 export WG_WIREGUARD_PRIVATE_KEY="$(wg genkey)"
 
 docker run \


### PR DESCRIPTION
This generates a 64 character password by default when used with the `docker run` command. This might be more secure than using `example` in the workflow, since some just copy and paste the command anyway and thus use an insecure admin password.