### PR TITLE
Always run linting workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,22 +1,13 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches:
+      - master
   schedule:
     - cron: '45 9 * * 1'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Publish Docker image
 on:
   push:
     branches:
-      - 'master'
+      - master
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,11 +2,10 @@ name: Linting
 
 on:
   push:
-    branches: [master, main]
+    branches:
+      - master
     tags-ignore: ['**']
-    paths-ignore: ['**.md']
   pull_request:
-    paths-ignore: ['**.md']
 
 jobs: # Docs: <https://git.io/JvxXE>
   gitleaks:


### PR DESCRIPTION
## Problem
The linting workflow does not run on PRs that only change markdown files. While this is nice in theory because we don't lint markdown files and it would save GitHub some computing power by not starting unnecessary workflows, this conflicts with the "Require successful status checks before merging" setting – those checks never succeed because they never run.
And apparently GitHub isn't smart enough to detect that and exclude them from the required list.

Now, GitHub suggests an [ugly hack as a workaround](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks). We are supposed to create duplicate workflows with the same name, that run exactly whenever the real workflow doesn't run.
I don't like this, this gets real messy real fast.

## Changes
Instead, let's just run the linting jobs all the time. They are pretty light anyway.

While I was on it, I've cleaned the workflow files up a bit. The `on.push.branches: master` is now formatted the same everywhere, and `types: [opened, synchronize, reopened]` has been removed from `build.yml` because [that's the default](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request).