### PR TITLE
Add CAP_SYS_MODULE to Docker commands and docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@ docker run \
   -it \
   --rm \
   --cap-add NET_ADMIN \
+  --cap-add SYS_MODULE \
   --device /dev/net/tun:/dev/net/tun \
   --sysctl net.ipv6.conf.all.disable_ipv6=0 \
   --sysctl net.ipv6.conf.all.forwarding=1 \
   -v wg-access-server-data:/data \
-  -v /lib/modules:/lib/modules \
+  -v /lib/modules:/lib/modules:ro \
   -e "WG_ADMIN_PASSWORD=$WG_ADMIN_PASSWORD" \
   -e "WG_WIREGUARD_PRIVATE_KEY=$WG_WIREGUARD_PRIVATE_KEY" \
   -p 8000:8000/tcp \
@@ -87,8 +88,9 @@ helm delete my-release
 Download the the docker-compose.yml file from the repo and run the following command.
 
 ```bash
-export WG_ADMIN_PASSWORD="example"
+export WG_ADMIN_PASSWORD=$(tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1)
 export WG_WIREGUARD_PRIVATE_KEY="$(wg genkey)"
+echo "Your automatically generated admin password for the wg-access-server's web interface: $WG_ADMIN_PASSWORD"
 
 docker-compose up
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,12 @@ services:
     container_name: wg-access-server
     cap_add:
       - NET_ADMIN
+      - SYS_MODULE
     sysctls:
       net.ipv6.conf.all.disable_ipv6: 0
       net.ipv6.conf.all.forwarding: 1
     volumes:
+      - "/lib/modules:/lib/modules:ro"
       - "wg-access-server-data:/data"
     #   - "./config.yaml:/config.yaml" # if you have a custom config file
     environment:

--- a/docs/deployment/2-docker-compose.md
+++ b/docs/deployment/2-docker-compose.md
@@ -1,10 +1,10 @@
 # Docker Compose
 
-You can run wg-access-server using the following example
-Docker Compose file.
+You can run wg-access-server using the following example Docker Compose file.
 
-Checkout the [configuration docs](../2-configuration.md) to learn how wg-access-server
-can be configured.
+Checkout the [configuration docs](../2-configuration.md) to learn how wg-access-server can be configured.
+
+Please also read the [Docker instructions](../1-docker.md) for general information regarding Docker deployments.
 
 ```yaml
 {!../docker-compose.yml!}


### PR DESCRIPTION
## Problem
As it turns out, `CAP_NET_ADMIN` and the bind-mount of `/lib/modules` aren't enough to load the ip_tables/ip6_tables kernel modules.
`docker run` with `-v /lib/modules:/lib/modules` and `--cap-add NET_ADMIN` but without `--cap-add SYS_MODULE` results in
```
FATA[0000]main.go:129 failed to read table filter: running [/sbin/ip6tables -t filter -S WG_ACCESS_SERVER_FORWARD 1 --wait]: exit status 3: modprobe: can't load module ip6_tables (kernel/net/ipv6/netfilter/ip6_tables.ko): Operation not permitted
```
`docker run` with `--cap-add NET_ADMIN --cap-add SYS_MODULE` and without `-v /lib/modules:/lib/modules` returns
```
FATA[0000]main.go:129 failed to read table filter: running [/sbin/ip6tables -t filter -S WG_ACCESS_SERVER_FORWARD 1 --wait]: exit status 3: modprobe: can't change directory to '/lib/modules': No such file or directory
```

## Changes
Add the SYS_MODULE capability to the Docker and docker-compose instructions, and add the modules bind-mount to the docker-compose instructions where they have been missing so far.

I've also made the `/lib/modules` bind-mount read-only everywhere. This seems to work, and the container should not be able to overwrite or place new modules in this directory.

I've also added a note to 1-docker.md about the danger of `SYS_MODULE`. A container with this capability can run arbitrary code in the kernel. An attacker can easily break out of the container and have full privileged host access (https://tbhaxor.com/container-breakout-part-2/ ; https://blog.nody.cc/posts/container-breakouts-part2/).
One can avoid this issue by pre-loading the kernel modules on the host.

Fixes #103