### PR TITLE
When only a single auth is enabled, dont show auth selector

### DIFF
--- a/docs/2-configuration.md
+++ b/docs/2-configuration.md
@@ -5,9 +5,8 @@ taking precedence over one another in that order.
 
 The default configuration should work out of the box if you're just looking to try it out.
 
-The only required configuration is an admin password and a wireguard private key. The admin
-password can be anything you like. You can generate a wireguard private key by
-[following the official docs](https://www.wireguard.com/quickstart/#key-generation).
+The only required configuration is a wireguard private key.
+You can generate a wireguard private key by [following the official docs](https://www.wireguard.com/quickstart/#key-generation).
 
 TLDR:
 

--- a/pkg/authnz/authconfig/authconfig.go
+++ b/pkg/authnz/authconfig/authconfig.go
@@ -14,6 +14,14 @@ func (c *AuthConfig) IsEnabled() bool {
 	return c.OIDC != nil || c.Gitlab != nil || c.Basic != nil
 }
 
+func (c *AuthConfig) DesiresSigninPage() bool {
+	if c.Basic != nil {
+		// Basic auth is the only that truely needs the signin button
+		return true
+	}
+	return false
+}
+
 func (c *AuthConfig) Providers() []*authruntime.Provider {
 	providers := []*authruntime.Provider{}
 

--- a/pkg/authnz/authconfig/authconfig.go
+++ b/pkg/authnz/authconfig/authconfig.go
@@ -16,7 +16,7 @@ func (c *AuthConfig) IsEnabled() bool {
 
 func (c *AuthConfig) DesiresSigninPage() bool {
 	if c.Basic != nil {
-		// Basic auth is the only that truely needs the signin button
+		// Basic auth is the only that truly needs the signin button
 		return true
 	}
 	return false

--- a/pkg/authnz/router.go
+++ b/pkg/authnz/router.go
@@ -41,6 +41,11 @@ func New(config authconfig.AuthConfig, claimsMiddleware authsession.ClaimsMiddle
 	}
 
 	router.HandleFunc("/signin", func(w http.ResponseWriter, r *http.Request) {
+		if !config.DesiresSigninPage() && len(providers) == 1 {
+			// we only have one proider, so jump directly to that
+			providers[0].Invoke(w, r, runtime)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprint(w, authtemplates.RenderLoginPage(w, authtemplates.LoginPage{
 			Providers: providers,


### PR DESCRIPTION
* Allow disabling of basic auth by not providing any basic config && having another auth setup
* When only a single auth is enabled, don't bother with the selection of auth types screen, just start the process

As you might have been able to tell with all the recent PRs, I'm using the OIDC flow ~(I think I might have been the original one to abstract the gitlab flow out to oidc~ nope I abstracted storage). I'm trying out https://goauthentik.io/ which is an open source okta. The flow for it is not ideal.

auth.domain.com => select VPN => goto wg-access-server -> select oidc -> goto authentik -> back to wg-access server

With this patch it becomes

auth.domain.com => select VPN

Assuming no other auths are enabled.

Also, I don't need nor want a static admin password. I can either redploy if I want one, so don't make it mandatory if other auths are setup

Closes #135 