### PR TITLE
Fix panic on nil LastHandshakeTime in metadata sync

### DIFF
--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -280,8 +280,5 @@ func deviceListContains(devices []*storage.Device, publicKey string) bool {
 }
 
 func IsConnected(lastHandshake time.Time) bool {
-	// if lastHandshake == nil {
-	// 	return false
-	// }
 	return lastHandshake.After(time.Now().Add(-3 * time.Minute))
 }

--- a/internal/devices/metadata.go
+++ b/internal/devices/metadata.go
@@ -30,7 +30,7 @@ func syncMetrics(d *DeviceManager) {
 		// they may actually be connected to another replica.
 		if peer.Endpoint != nil {
 			if device, err := d.GetByPublicKey(peer.PublicKey.String()); err == nil {
-				if !IsConnected(peer.LastHandshakeTime) && !IsConnected(*device.LastHandshakeTime) {
+				if !IsConnected(peer.LastHandshakeTime) && device.LastHandshakeTime != nil && !IsConnected(*device.LastHandshakeTime) {
 					// Not connected, and we haven't been the last time either, nothing to update
 					continue
 				}


### PR DESCRIPTION
## Problems
`device.LastHandshakeTime` can be nil in some cases (newly created device?), which `devices.syncMetrics()` didn't account for in #66.
```
wg-access-server  | panic: runtime error: invalid memory address or nil pointer dereference
wg-access-server  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x93fc8c]
wg-access-server  | 
wg-access-server  | goroutine 300 [running]:
wg-access-server  | github.com/freifunkMUC/wg-access-server/internal/devices.syncMetrics(0xc0000a5540)
wg-access-server  |     /code/internal/devices/metadata.go:33 +0x24c
wg-access-server  | github.com/freifunkMUC/wg-access-server/internal/devices.metadataLoop(0x0)
wg-access-server  |     /code/internal/devices/metadata.go:12 +0x1e
wg-access-server  | created by github.com/freifunkMUC/wg-access-server/internal/devices.(*DeviceManager).StartSync
wg-access-server  |     /code/internal/devices/devices.go:58 +0x165
```

## Changes
Now we check it for nil before dereferencing. All other places where we read LastHandshakeTime are fine.