### PR TITLE
Update wg-embed to v0.6.0 and pg-events to v0.4.0

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/docker/libnetwork/resolvconf"
 	"github.com/docker/libnetwork/types"
+	"github.com/freifunkMUC/wg-embed/pkg/wgembed"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
-	"github.com/place1/wg-embed/pkg/wgembed"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/crypto/bcrypt"

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/coreos/go-iptables v0.6.0
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/docker/libnetwork v0.8.0-dev.2.0.20200217033114-6659f7f4d8c1
+	github.com/freifunkMUC/pg-events v0.4.0
+	github.com/freifunkMUC/wg-embed v0.6.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
@@ -16,8 +18,6 @@ require (
 	github.com/miekg/dns v1.1.46
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
-	github.com/place1/pg-events v0.2.0
-	github.com/place1/wg-embed v0.4.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tg123/go-htpasswd v1.2.0
@@ -68,15 +68,10 @@ require (
 	golang.zx2c4.com/wireguard v0.0.0-20211129173154-2dd424e2d808 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210930144712-2e2e1008e8a3 // indirect
-	gopkg.in/ini.v1 v1.66.2 // indirect
+	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	gotest.tools v2.2.0+incompatible // indirect
 	gotest.tools/v3 v3.0.3 // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
-)
-
-replace (
-	github.com/place1/pg-events => github.com/freifunkMUC/pg-events v0.3.0
-	github.com/place1/wg-embed => github.com/freifunkMUC/wg-embed v0.5.2
 )

--- a/go.sum
+++ b/go.sum
@@ -128,10 +128,10 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
-github.com/freifunkMUC/pg-events v0.3.0 h1:S86hHujIyJf0jc9kG5r8kxPo83TTMJXNhkwPS+i2kR8=
-github.com/freifunkMUC/pg-events v0.3.0/go.mod h1:WpQ7S07fp3UWq/HKmRWnJLwXtqGa6VSsqJQdrly+5mY=
-github.com/freifunkMUC/wg-embed v0.5.2 h1:S0+PwDP7tnsUhfYjWo62PxMvLUNFEo2YWXyw0AABPHI=
-github.com/freifunkMUC/wg-embed v0.5.2/go.mod h1:9Zr8ryEtVHESqzzSOkcThoynoPUiEHTKur/94gCN7zY=
+github.com/freifunkMUC/pg-events v0.4.0 h1:LSSYZgdkEAr+dzcotxyibXYwW4UQOFCNmno3c09Z7do=
+github.com/freifunkMUC/pg-events v0.4.0/go.mod h1:RIANURwUzHVI17cZzIoK5X/+MRUgBWx5fpksO4beOoQ=
+github.com/freifunkMUC/wg-embed v0.6.0 h1:3+JRjN8tUfiVkL07/uzPZZ7RMpOZ9Ya4hCSAzFwGF+0=
+github.com/freifunkMUC/wg-embed v0.6.0/go.mod h1:WCz8WhEzhTMYSzsIyahe92JhkNVC35ALSloRedAWcCU=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
@@ -914,8 +914,8 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.29.1/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
-gopkg.in/ini.v1 v1.66.2 h1:XfR1dOYubytKy4Shzc2LHrrGhU0lDCfDGG1yLPmpgsI=
-gopkg.in/ini.v1 v1.66.2/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/ini.v1 v1.66.4 h1:SsAcf+mM7mRZo2nJNGt8mZCjG8ZRaNGMURJw7BsIST4=
+gopkg.in/ini.v1 v1.66.4/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
 gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -10,8 +10,8 @@ import (
 	"github.com/freifunkMUC/wg-access-server/internal/storage"
 	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authsession"
 
+	"github.com/freifunkMUC/wg-embed/pkg/wgembed"
 	"github.com/pkg/errors"
-	"github.com/place1/wg-embed/pkg/wgembed"
 	"github.com/sirupsen/logrus"
 )
 

--- a/internal/services/api_router.go
+++ b/internal/services/api_router.go
@@ -6,14 +6,14 @@ import (
 	"math"
 	"net/http"
 
-	"github.com/place1/wg-embed/pkg/wgembed"
-
-	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
-	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/freifunkMUC/wg-access-server/internal/config"
 	"github.com/freifunkMUC/wg-access-server/internal/devices"
 	"github.com/freifunkMUC/wg-access-server/internal/traces"
 	"github.com/freifunkMUC/wg-access-server/proto/proto"
+
+	"github.com/freifunkMUC/wg-embed/pkg/wgembed"
+	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
+	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"google.golang.org/grpc"
 )
 

--- a/internal/services/server_service.go
+++ b/internal/services/server_service.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"strings"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
-	"github.com/freifunkMUC/wg-access-server/internal/network"
-
 	"github.com/freifunkMUC/wg-access-server/internal/config"
+	"github.com/freifunkMUC/wg-access-server/internal/network"
 	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authsession"
 	"github.com/freifunkMUC/wg-access-server/proto/proto"
-	"github.com/place1/wg-embed/pkg/wgembed"
+
+	"github.com/freifunkMUC/wg-embed/pkg/wgembed"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/internal/storage/pgwatcher.go
+++ b/internal/storage/pgwatcher.go
@@ -3,8 +3,8 @@ package storage
 import (
 	"encoding/json"
 
+	"github.com/freifunkMUC/pg-events/pkg/pgevents"
 	"github.com/pkg/errors"
-	"github.com/place1/pg-events/pkg/pgevents"
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
This updates wg-embed and pg-events to their latest tags to pull in https://github.com/freifunkMUC/wg-embed/pull/8 and https://github.com/freifunkMUC/pg-events/pull/5 and removes the `replace directives`, after which it should finally be possible to download install the binary using `go install` for those that need it. (Of course, the frontend files still need to be downloaded and built separately).