### PR TITLE
Add optional client isolation feature for blocking traffic between devices

### DIFF
--- a/docs/2-configuration.md
+++ b/docs/2-configuration.md
@@ -36,6 +36,7 @@ Here's what you can configure:
 | `WG_VPN_CIDR`              | `--vpn-cidr`               | `vpn.cidr`             |          | `10.44.0.0/24`                               | The VPN IPv4 network range. VPN clients will be assigned IP addresses in this range. Set to `0` to disable IPv4.                                                                   |
 | `WG_IPV4_NAT_ENABLED`      | `--vpn-nat44-enabled`      | `vpn.nat44`            |          | `true`                                       | Disables NAT for IPv4                                                                                                                                                              |
 | `WG_IPV6_NAT_ENABLED`      | `--vpn-nat66-enabled`      | `vpn.nat66`            |          | `true`                                       | Disables NAT for IPv6                                                                                                                                                              |
+| `WG_VPN_CLIENT_ISOLATION`  | `--vpn-client-isolation`   | `vpn.clientIsolation`  |          | `false`                                      | BLock or allow traffic between client devices (client isolation)                                                                                                                   |
 | `WG_VPN_CIDRV6`            | `--vpn-cidrv6`             | `vpn.cidrv6`           |          | `fd48:4c4:7aa9::/64`                         | The VPN IPv6 network range. VPN clients will be assigned IP addresses in this range. Set to `0` to disable IPv6.                                                                   |
 | `WG_VPN_GATEWAY_INTERFACE` | `--vpn-gateway-interface`  | `vpn.gatewayInterface` |          | _default gateway interface (e.g. eth0)_      | The VPN gateway interface. VPN client traffic will be forwarded to this interface.                                                                                                 |
 | `WG_VPN_ALLOWED_IPS`       | `--vpn-allowed-ips`        | `vpn.allowedIPs`       |          | `0.0.0.0/0, ::/0`                            | Allowed IPs that clients may route through this VPN. This will be set in the client's WireGuard connection file and routing is also enforced by the server using iptables.         |
@@ -54,5 +55,6 @@ wireguard:
   privateKey: "<some-key>"
 dns:
   upstream:
+    - "2001:4860:4860::8888"
     - "8.8.8.8"
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,12 @@ type AppConfig struct {
 	} `yaml:"wireguard"`
 	// Configure VPN related settings (networking)
 	VPN struct {
+		// The "AllowedIPs" for VPN clients.
+		// This value will be included in client config
+		// files and in server-side iptable rules
+		// to enforce network access.
+		// defaults to ["0.0.0.0/0", "::/0"]
+		AllowedIPs []string `yaml:"allowedIPs"`
 		// CIDR configures a network address space
 		// that client (WireGuard peers) will be allocated
 		// an IP address from
@@ -64,6 +70,11 @@ type AppConfig struct {
 		// an IP address from
 		// defaults to fd48:4c4:7aa9::/64
 		CIDRv6 string `yaml:"cidrv6"`
+		// GatewayInterface will be used in iptable forwarding
+		// rules that send VPN traffic from clients to this interface
+		// Most use-cases will want this interface to have access
+		// to the outside internet
+		GatewayInterface string `yaml:"gatewayInterface"`
 		// NAT44 configures whether IPv4 traffic leaving
 		// through the GatewayInterface should be masqueraded
 		// defaults to true
@@ -73,17 +84,9 @@ type AppConfig struct {
 		// masqueraded like IPv4 traffic
 		// defaults to true
 		NAT66 bool `yaml:"nat66"`
-		// GatewayInterface will be used in iptable forwarding
-		// rules that send VPN traffic from clients to this interface
-		// Most use-cases will want this interface to have access
-		// to the outside internet
-		GatewayInterface string `yaml:"gatewayInterface"`
-		// The "AllowedIPs" for VPN clients.
-		// This value will be included in client config
-		// files and in server-side iptable rules
-		// to enforce network access.
-		// defaults to ["0.0.0.0/0", "::/0"]
-		AllowedIPs []string `yaml:"allowedIPs"`
+		// ClientIsolation configures whether traffic between client devices will be blocked or allowed
+		// defaults to false
+		ClientIsolation bool `yaml:"clientIsolation"`
 	} `yaml:"vpn"`
 	// Configure the embedded DNS server
 	DNS struct {


### PR DESCRIPTION
## Motivation
Until now there was absolutely no firewall between all online devices.
While this is not problem (and often even wanted behaviour) for single-user setups,
it can be useful for multi-user situations.

## Changes
A new option `WG_VPN_CLIENT_ISOLATION`/`--vpn-client-isolation`/`vpn.clientIsolation` is added.
It defaults to false, and if set to true it will `REJECT` (port unreachable) all packets coming from one client device IP address to another.
We do not need to explicitly allow traffic to the server, as that one goes through the `INPUT` table, not `FORWARD`.

Note that this does not affect incoming traffic from outside the VPN. This one can and should still be configured externally, wg-access-server does not drop incoming traffic (yet).