### PR TITLE
Document pgbouncer not working in 'Transaction pooling' mode

### DIFF
--- a/docs/3-storage.md
+++ b/docs/3-storage.md
@@ -16,7 +16,7 @@ wg-access-server supports 4 storage backends.
 This is the default backend if you're running the binary directly and haven't configured
 another storage backend. Data will be lost between restarts. Handy for development.
 
-### Sqlite3
+### SQLite3
 
 This is the default backend if you're running the docker container directly or using docker-compose.
 
@@ -31,18 +31,20 @@ Example connection string:
 - Relative path: `sqlite3://path/to/db.sqlite3`
 - Absolute path: `sqlite3:///absolute/path/to/db.sqlite3`
 
-### Postgres
+### PostgreSQL
 
 This backend requires an external Postgres database to be deployed.
 
-Postgres will support highly-available deployments of wg-access-server in the near future
+Postgres experimentally supports highly-available deployments of wg-access-server
 and is the recommended storage backend where possible.
+If you have pgbouncer running in front of PostgreSQL, make sure it is running in "Session pooling" mode,
+as the more aggressive modes like "Transaction Pooling" break LISTEN/NOTIFY which we rely on.
 
 Example connection string:
 
 - `postgresql://user:password@localhost:5432/database?sslmode=disable`
 
-### Mysql
+### MySQL
 
 This backend requires an external Mysql database to be deployed. Mysql flavours should be compatible.
 wg-access-server uses [this golang driver](github.com/go-sql-driver/mysql) if you want to check the


### PR DESCRIPTION
## Problem
pgbouncer breaks LISTEN/NOTIFY in "Transaction pooling" mode: https://www.pgbouncer.org/features.html
> **SQL feature map for pooling modes**
>
> Feature | Session pooling | Transaction pooling
> -- | -- | --
> LISTEN/NOTIFY | Yes | Never

Our pg-watcher / pg-events / [github.com/lib/pq](https://github.com/lib/pq) depend on those though, in order to report back newly created devices to the wireguard interface.

## Changes
Added a note to 3-storage.md to let people know to use "Session pooling" instead.

In the future we could consider an automatic fallback to gormwatcher. It doesn't work with HA, but would allow single-instance deployments behind "Transaction pooling" pgbouncers. If there's a supported way to detect whether we run behind pgbouncer and which mode it is in.

Fixes #151 