### PR TITLE
Allow comma as list separator for environment variables

### DIFF
--- a/docs/2-configuration.md
+++ b/docs/2-configuration.md
@@ -16,6 +16,15 @@ wg genkey
 
 The config file format is `yaml` and an example is provided [below](#the-config-file-configyaml).
 
+The format for specifying multiple values for options that allow it is:
+* as commandline flags:
+  * repeat the flag (e.g. `--dns-upstream 2001:db8::1 --dns-upstream 192.0.2.1`)
+  * separate the values with a comma (e.g. `--dns-upstream 2001:db8::1,192.0.2.1`)
+* as environment variables:
+  * separate with a comma (e.g. `WG_DNS_UPSTREAM="2001:db8::1,192.0.2.1"`)
+  * separate with a new line char (e.g. `WG_DNS_UPSTREAM=$'2001:db8::1\n192.0.2.1'`)
+* in the config file as YAML list.
+
 Here's what you can configure:
 
 | Environment Variable       | CLI Flag                   | Config File Path       | Required | Default (docker)                             | Description                                                                                                                                                                        |
@@ -40,7 +49,7 @@ Here's what you can configure:
 | `WG_VPN_GATEWAY_INTERFACE` | `--vpn-gateway-interface`  | `vpn.gatewayInterface` |          | _default gateway interface (e.g. eth0)_      | The VPN gateway interface. VPN client traffic will be forwarded to this interface.                                                                                                 |
 | `WG_VPN_ALLOWED_IPS`       | `--vpn-allowed-ips`        | `vpn.allowedIPs`       |          | `0.0.0.0/0, ::/0`                            | Allowed IPs that clients may route through this VPN. This will be set in the client's WireGuard connection file and routing is also enforced by the server using iptables.         |
 | `WG_DNS_ENABLED`           | `--[no-]dns-enabled`       | `dns.enabled`          |          | `true`                                       | Enable/disable the embedded DNS proxy server. This is enabled by default and allows VPN clients to avoid DNS leaks by sending all DNS requests to wg-access-server itself.         |
-| `WG_DNS_UPSTREAM`          | `--dns-upstream`           | `dns.upstream`         |          | _resolvconf autodetection or Cloudflare DNS_ | The upstream DNS server to proxy DNS requests to. By default the host machine's resolveconf configuration is used to find it's upstream DNS server, with a fallback to Cloudflare. |
+| `WG_DNS_UPSTREAM`          | `--dns-upstream`           | `dns.upstream`         |          | _resolvconf autodetection or Cloudflare DNS_ | The upstream DNS servers to proxy DNS requests to. By default the host machine's resolveconf configuration is used to find its upstream DNS server, with a fallback to Cloudflare. |
 | `WG_DNS_DOMAIN`            | `--dns-domain`             | `dns.domain`           |          |                                              | A domain to serve configured devices authoritatively. Queries for names in the format <device>.<user>.<domain> will be answered with the device's IP addresses.                    |
 
 ## The Config File (config.yaml)


### PR DESCRIPTION
## Problem
Our cmdline argument / environment variable parsing library requires elements of lists in env vars to be separated by new line chars.
This is both unintuitive and inconvenient, apparently `export SOMETHING="A\nB"` does not work (but `export SOMETHING=$'A\nB'` [might](https://unix.stackexchange.com/a/20039)).
It would be nice if we could allow commas as well, which is pretty common.

## Changes
Now for the two options that take a list, `WG_DNS_UPSTREAM` and `WG_VPN_ALLOWED_IPS`, if the parsing library only returns one element, we try to split it at `,`.
This does not only apply to when they are specified through env vars, but also through cmdline flags or the config file.

Currently this is pretty simple because none of these options allow input that contains a comma, if we ever do get such an option we might have to make it more sophisticated (or just require it to be specified in the config file).

I've also moved all the config input "sanitization" code into `ReadConfig()`, makes more sense there and keeps `Run()` tidy.

Fixes #136 