### PR TITLE
Fix grpc recover and logging

### DIFF
--- a/internal/services/health.go
+++ b/internal/services/health.go
@@ -6,8 +6,8 @@ import (
 )
 
 func HealthEndpoint() http.Handler {
-	return http.HandlerFunc(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		fmt.Fprintf(w, "ok")
-	}))
+	})
 }

--- a/internal/services/middleware.go
+++ b/internal/services/middleware.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
 	"github.com/freifunkMUC/wg-access-server/internal/traces"
 )
 
@@ -19,7 +18,7 @@ func RecoveryMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if err := recover(); err != nil {
-				ctxlogrus.Extract(r.Context()).
+				traces.Logger(r.Context()).
 					WithField("stack", string(debug.Stack())).
 					Error(err)
 				w.WriteHeader(500)


### PR DESCRIPTION
## Problem
While looking at #119 I discovered that the existing `RecoveryMiddleware` doesn't actually work for panics in gRPC code / API calls. This is because the grpc library handles the requests in goroutines, and `recover()` can only work for panics in the same goroutine.
https://github.com/grpc/grpc-go/blob/431ea809a7676e1da8d09c33ae0d31fcba85f1ff/server.go#L920-L923

And while it does recover for non-gRPC calls, like the login flow, the logging doesn't actually work because `ctxlogrus` is a noop logger in this case.

This can make setting up OIDC annoying like in #154, because it's just failing and not telling you why.

The OIDC callback handler is broken if the `name` claim is missing, despite it being optional in the [spec](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse) and in the rest of the application.

## Changes
We handle a missing `name` claim in the OIDC User Info gracefully.

`RecoveryMiddleware` now logs using `traces.Logger`, not `ctxlogrus`.

For gRPC we make use of [github.com/grpc-ecosystem/go-grpc-middleware](https://github.com/grpc-ecosystem/go-grpc-middleware)'s [grpc_recovery](https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/recovery) interceptor to recover from panics. It has a custom handler to attach the trace id to the error message so it's visible to the client (e.g. in the `Grpc-Message` header).

The log lines will look like this:

panic in gRPC API code:
```
ERRO[0006]options.go:224 finished unary call with code Internal        error="rpc error: code = Internal desc = something trace = 884660dd-ead7-41c4-b1bb-8f36162ed198" grpc.code=Internal grpc.method=Info grpc.service=proto.Server grpc.start_time="2022-04-05T15:29:36+02:00" grpc.time_ms=0.019 span.kind=server system=grpc trace.id=884660dd-ead7-41c4-b1bb-8f36162ed198

```
panic in other HTTP handling code (actual log entry will have new lines escaped to `\n`):
```
ERRO[0103]middleware.go:23 something                                     stack="goroutine 61 [running]:
runtime/debug.Stack()
	go/src/runtime/debug/stack.go:24 +0x65
github.com/freifunkMUC/wg-access-server/internal/services.RecoveryMiddleware.func1.1()
	wg-access-server/internal/services/middleware.go:22 +0xa5
panic({0xc9e0a0, 0xef9640})
	go/src/runtime/panic.go:838 +0x207
github.com/freifunkMUC/wg-access-server/pkg/authnz/authconfig.(*OIDCConfig).loginHandler.func1({0x8451b1?, 0xc000410190?}, 0xc0000f40e0?)
	wg-access-server/pkg/authnz/authconfig/oidc.go:74 +0x27
github.com/freifunkMUC/wg-access-server/pkg/authnz/authconfig.(*OIDCConfig).Provider.func1({0xf01770, 0xc000758000}, 0xdcb568?, 0x5?)
	wg-access-server/pkg/authnz/authconfig/oidc.go:63 +0x56
github.com/freifunkMUC/wg-access-server/pkg/authnz.New.func2({0xf01770, 0xc000758000}, 0xc0001b6870?)
	wg-access-server/pkg/authnz/router.go:63 +0xfc
net/http.HandlerFunc.ServeHTTP(0xc000328600?, {0xf01770?, 0xc000758000?}, 0xc00017f710?)
	go/src/net/http/server.go:2084 +0x2f
github.com/gorilla/mux.(*Router).ServeHTTP(0xc00012e0c0, {0xf01770, 0xc000758000}, 0xc000328500)
	mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0x1cf
github.com/freifunkMUC/wg-access-server/pkg/authnz.(*AuthMiddleware).Middleware.func1({0xf01770, 0xc000758000}, 0xc000328500)
	wg-access-server/pkg/authnz/router.go:93 +0x494
net/http.HandlerFunc.ServeHTTP(0xc9e0a0?, {0xf01770?, 0xc000758000?}, 0x88?)
	go/src/net/http/server.go:2084 +0x2f
github.com/freifunkMUC/wg-access-server/internal/services.RecoveryMiddleware.func1({0xf01770?, 0xc000758000?}, 0xc00017f801?)
	wg-access-server/internal/services/middleware.go:28 +0x83
net/http.HandlerFunc.ServeHTTP(0xf01e80?, {0xf01770?, 0xc000758000?}, 0xc00017f960?)
	go/src/net/http/server.go:2084 +0x2f
github.com/freifunkMUC/wg-access-server/internal/services.TracesMiddleware.func1({0xf01770, 0xc000758000}, 0xc000328300)
	wg-access-server/internal/services/middleware.go:13 +0x230
net/http.HandlerFunc.ServeHTTP(0xc000328100?, {0xf01770?, 0xc000758000?}, 0x0?)
	go/src/net/http/server.go:2084 +0x2f
github.com/gorilla/mux.(*Router).ServeHTTP(0xc00012e000, {0xf01770, 0xc000758000}, 0xc0001fe700)
	mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0x1cf
net/http.serverHandler.ServeHTTP({0xc000685f20?}, {0xf01770, 0xc000758000}, 0xc0001fe700)
	go/src/net/http/server.go:2916 +0x43b
net/http.(*conn).serve(0xc0000bf220, {0xf01e80, 0xc000685e00})
	go/src/net/http/server.go:1966 +0x5d7
created by net/http.(*Server).Serve
	go/src/net/http/server.go:3071 +0x4db
" trace.id=2052a13b-66ca-4a86-986f-36aa3dad2691
```

Fixes #118 
Fixes #154