### PR TITLE
Use WG kernel module implementation if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ NAT can be disabled separately for IPv4 and IPv6.
 
 - Pluggable authentication using OpenID Connect
 - Authentication using GitLab
+- PostgreSQL, MySQL or SQLite3 storage backend
+- WireGuard client configuration QR codes
 - IPv6 support in tunnel
 - Caching DNS proxy (stub resolver)
-- WireGuard client configuration QR codes
-- PostgreSQL, MySQL or SQLite3 storage backend
+- Client isolation (optional)
+- WireGuard kernel module for improved performance and latency
+- Automatic fallback to embedded userspace implementation for easy container deployment
 
 ## Documentation
 

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -108,7 +108,11 @@ func (cmd *servecmd) Run() {
 	// WireGuard Server
 	wg := wgembed.NewNoOpInterface()
 	if conf.WireGuard.Enabled {
-		wgimpl, err := wgembed.New(conf.WireGuard.Interface)
+		wgOpts := wgembed.Options{
+			InterfaceName:     conf.WireGuard.Interface,
+			AllowKernelModule: true,
+		}
+		wgimpl, err := wgembed.NewWithOpts(wgOpts)
 		if err != nil {
 			logrus.Fatal(errors.Wrap(err, "failed to create wireguard interface"))
 		}

--- a/docs/deployment/1-docker.md
+++ b/docs/deployment/1-docker.md
@@ -1,12 +1,13 @@
 # Docker
 
-Load the `ip_tables` and `ip6_tables` kernel modules on the host.
+Load the `ip_tables`, `ip6_tables` and `wireguard` kernel modules on the host.
 
 ```bash
-modprobe ip_tables && modprobe ip6_tables
+modprobe ip_tables && modprobe ip6_tables && modprobe wireguard
 # Load modules on boot
 echo ip_tables >> /etc/modules
 echo ip6_tables >> /etc/modules
+echo wireguard >> /etc/modules
 ```
 
 ```bash
@@ -27,9 +28,12 @@ docker run \
 
 ## Modules
 
-If you are unable to load the kernel modules, you can add the `SYS_MODULE` capability instead: `--cap-add SYS_MODULE`. You must also add the following mount: `-v /lib/modules:/lib/modules:ro`.
+If you are unable to load the `iptables` kernel modules, you can add the `SYS_MODULE` capability instead: `--cap-add SYS_MODULE`. You must also add the following mount: `-v /lib/modules:/lib/modules:ro`.
 
 This is not recommended as it essentially gives the container root privileges over the host system and an attacker could easily break out of the container.
+
+The WireGuard module should be loaded automatically, even without `SYS_MODULE` capability or `/lib/modules` mount.
+If it still fails to load, the server automatically falls back to the userspace implementation. 
 
 ## IPv4-only (without IPv6)
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/docker/libnetwork v0.8.0-dev.2.0.20200217033114-6659f7f4d8c1
 	github.com/freifunkMUC/pg-events v0.4.0
-	github.com/freifunkMUC/wg-embed v0.6.0
+	github.com/freifunkMUC/wg-embed v0.7.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/freifunkMUC/pg-events v0.4.0 h1:LSSYZgdkEAr+dzcotxyibXYwW4UQOFCNmno3c09Z7do=
 github.com/freifunkMUC/pg-events v0.4.0/go.mod h1:RIANURwUzHVI17cZzIoK5X/+MRUgBWx5fpksO4beOoQ=
-github.com/freifunkMUC/wg-embed v0.6.0 h1:3+JRjN8tUfiVkL07/uzPZZ7RMpOZ9Ya4hCSAzFwGF+0=
-github.com/freifunkMUC/wg-embed v0.6.0/go.mod h1:WCz8WhEzhTMYSzsIyahe92JhkNVC35ALSloRedAWcCU=
+github.com/freifunkMUC/wg-embed v0.7.0 h1:mmyqhlEDnvd9fOSnm+Ig+oB0wji7gDdXbQZzc8Ezbb0=
+github.com/freifunkMUC/wg-embed v0.7.0/go.mod h1:WCz8WhEzhTMYSzsIyahe92JhkNVC35ALSloRedAWcCU=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=


### PR DESCRIPTION
This bumps wg-embed to v0.7.0 to pull in https://github.com/freifunkMUC/wg-embed/pull/9

See the linked pull request for more details.
To repeat the important things:
- We try to use the kernel module, if something throws an error while creating the interface we log it and automatically fall back to the embedded userspace/Go implementation.
- netlink will try to load the kernel module automatically, it only requires `CAP_NET_ADMIN` (already required for interface management), no `CAP_SYS_MODULE` or mount of `/lib/modules` into a Docker container.
  However 1-docker.md still says to load it on the host if possible, as this will be stabler and more future-proof.

You can check the running implementation either by checking for the `falling back to embedded Go implementation` log line, or running `ip -details link show` (inside the container). If created through the kernel module the link will show `wireguard` as first word in the third line, otherwise `tun`.