### PR TITLE
Revert "Bump golang from 1.18.0-alpine to 1.18.1-alpine"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY ./website/ ./
 RUN npm run build
 
 ### Build stage for the website backend server
-FROM golang:1.18.1-alpine as server
+FROM golang:1.18.0-alpine as server
 RUN apk add --no-cache gcc musl-dev
 WORKDIR /code
 ENV CGO_ENABLED=1


### PR DESCRIPTION
Reverts freifunkMUC/wg-access-server#162 as some architectures seem to not be available yet besides they show up in the manifest of golang on dockerhub