### PR TITLE
Add simple authentication backend to work around broken Basic Auth logout

### DIFF
--- a/docs/4-auth.md
+++ b/docs/4-auth.md
@@ -14,11 +14,16 @@ to a larger solution like this.
 
 The following authentication backends are currently supported:
 
-| Backend        | Use Case                                                                                      | Notes                                                         |
-| -------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| Basic Auth     | Deployments with a static list of users. Simple and great for self-hosters and home use-cases | The wg-access-server admin account is powered by this backend |
-| OpenID Connect | For delegating authentication to an existing identity solution                                |                                                               |
-| Gitlab         | For delegating authentication to gitlab. Supports self-hosted Gitlab.                         |                                                               |
+| Backend        | Use Case                                                                                      | Notes                                                               |
+|----------------|-----------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| Simple Auth    | Deployments with a static list of users. Simple and great for self-hosters and home use-cases | Recommended, default for the admin account                          |
+| Basic Auth     | Like Simple Auth, but using HTTP Basic Auth for login                                         | Logout does not work because browsers caches Basic Auth credentials |
+| OpenID Connect | For delegating authentication to an existing identity solution                                |                                                                     |
+| Gitlab         | For delegating authentication to gitlab. Supports self-hosted Gitlab.                         |                                                                     |
+
+If `adminPassword` is set, an administrator account will be added with the username of `adminUsername` (default `admin`)
+to the Simple Auth or Basic Auth backend; whichever is enabled, automatically enabling Simple if both are unset,
+preferring Simple to Basic if both are enabled.
 
 ## Configuration
 
@@ -28,8 +33,18 @@ config file (config.yaml).
 Below is an annotated example config section that can be used as a starting point.
 
 ```yaml
+# You can disable the builtin admin account by leaving out 'adminPassword'. Requires another backend to be configured.
+adminPassword: "<admin password>"
+# adminUsername sets the user for the Basic/Simple Auth admin account if adminPassword is set.
+# Every user of the basic and simple backend with a username matching adminUsername will have admin privileges.
+adminUsername: "admin"
 # Configure zero or more authentication backends
 auth:
+  simple:
+    # Users is a list of htpasswd encoded username:password pairs
+    # supports BCrypt, Sha, Ssha, Md5
+    # You can create a user using "htpasswd -nB <username>"
+    users: []
   # HTTP Basic Authentication
   basic:
     # Users is a list of htpasswd encoded username:password pairs

--- a/internal/services/device_service.go
+++ b/internal/services/device_service.go
@@ -59,7 +59,7 @@ func (d *DeviceService) DeleteDevice(ctx context.Context, req *proto.DeleteDevic
 	deviceOwner := user.Subject
 
 	if req.Owner != nil {
-		if user.Claims.Contains("admin") {
+		if user.Claims.Has("admin", "true") {
 			deviceOwner = req.Owner.Value
 		} else {
 			return nil, status.Errorf(codes.PermissionDenied, "must be an admin")
@@ -80,7 +80,7 @@ func (d *DeviceService) ListAllDevices(ctx context.Context, req *proto.ListAllDe
 		return nil, status.Errorf(codes.PermissionDenied, "not authenticated")
 	}
 
-	if !user.Claims.Contains("admin") {
+	if !user.Claims.Has("admin", "true") {
 		return nil, status.Errorf(codes.PermissionDenied, "must be an admin")
 	}
 

--- a/internal/services/server_service.go
+++ b/internal/services/server_service.go
@@ -63,7 +63,7 @@ func (s *ServerService) Info(ctx context.Context, req *proto.InfoReq) (*proto.In
 		// TODO IPv6 what is HostVpnIp used for, do we need HostVpnIpv6 as well?
 		HostVpnIp:       hostVPNIP,
 		MetadataEnabled: !s.Config.DisableMetadata,
-		IsAdmin:         user.Claims.Contains("admin"),
+		IsAdmin:         user.Claims.Has("admin", "true"),
 		AllowedIps:      allowedIPs(s.Config),
 		DnsEnabled:      s.Config.DNS.Enabled,
 		DnsAddress:      dnsAddress,

--- a/pkg/authnz/authconfig/authconfig.go
+++ b/pkg/authnz/authconfig/authconfig.go
@@ -5,13 +5,14 @@ import (
 )
 
 type AuthConfig struct {
-	OIDC   *OIDCConfig      `yaml:"oidc"`
-	Gitlab *GitlabConfig    `yaml:"gitlab"`
-	Basic  *BasicAuthConfig `yaml:"basic"`
+	OIDC   *OIDCConfig       `yaml:"oidc"`
+	Gitlab *GitlabConfig     `yaml:"gitlab"`
+	Basic  *BasicAuthConfig  `yaml:"basic"`
+	Simple *SimpleAuthConfig `yaml:"simple"`
 }
 
 func (c *AuthConfig) IsEnabled() bool {
-	return c.OIDC != nil || c.Gitlab != nil || c.Basic != nil
+	return c.OIDC != nil || c.Gitlab != nil || c.Basic != nil || c.Simple != nil
 }
 
 func (c *AuthConfig) DesiresSigninPage() bool {
@@ -32,6 +33,10 @@ func (c *AuthConfig) Providers() []*authruntime.Provider {
 
 	if c.Basic != nil {
 		providers = append(providers, c.Basic.Provider())
+	}
+
+	if c.Simple != nil {
+		providers = append(providers, c.Simple.Provider())
 	}
 
 	return providers

--- a/pkg/authnz/authconfig/basic.go
+++ b/pkg/authnz/authconfig/basic.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authruntime"
 	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authsession"
+
 	"github.com/tg123/go-htpasswd"
 )
 
@@ -34,7 +35,7 @@ func basicAuthLogin(c *BasicAuthConfig, runtime *authruntime.ProviderRuntime) ht
 			if ok := checkCreds(c.Users, u, p); ok {
 				err := runtime.SetSession(w, r, &authsession.AuthSession{
 					Identity: &authsession.Identity{
-						Provider: "basic",
+						Provider: "Basic",
 						Subject:  u,
 						Name:     u,
 						Email:    "", // basic auth has no email

--- a/pkg/authnz/authconfig/simple.go
+++ b/pkg/authnz/authconfig/simple.go
@@ -1,0 +1,92 @@
+package authconfig
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authruntime"
+	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authsession"
+	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authtemplates"
+)
+
+// SimpleAuthConfig is an alternative to BasicAuthConfig where the login happens through a login page and a POST request.
+type SimpleAuthConfig struct {
+	// Users is a list of htpasswd encoded username:password pairs
+	// supports BCrypt, Sha, Ssha, Md5
+	// example: "htpasswd -nB <username>"
+	// copy the result into your user's array
+	Users []string `yaml:"users"`
+}
+
+const postURL = "/signin/simpleauth"
+
+func (c *SimpleAuthConfig) Provider() *authruntime.Provider {
+	return &authruntime.Provider{
+		Type: "Simple",
+		// The flow is as follows: /signin page -> navigation to /signin/{index}
+		// -> Invoke / simpleAuthLogin() renders login form -> POST to postURL / simpleAuthPostEndpoint()
+		// -> redirect to /
+		Invoke: func(w http.ResponseWriter, r *http.Request, runtime *authruntime.ProviderRuntime) {
+			simpleAuthLogin()(w, r)
+		},
+		RegisterRoutes: func(router *mux.Router, runtime *authruntime.ProviderRuntime) error {
+			router.HandleFunc(postURL, simpleAuthPostEndpoint(c, runtime))
+			return nil
+		},
+	}
+}
+
+func simpleAuthLogin() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// A login page with a username and a password field
+		w.WriteHeader(http.StatusOK)
+		err := authtemplates.RenderSimpleAuthPage(w, authtemplates.SimpleAuthPage{PostURL: postURL})
+		if err != nil {
+			logrus.Error(errors.Wrap(err, "failed to render simple auth login page"))
+			return
+		}
+	}
+}
+
+func simpleAuthPostEndpoint(c *SimpleAuthConfig, runtime *authruntime.ProviderRuntime) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		err := r.ParseForm()
+		if err != nil {
+			http.Error(w, "Could not parse form", http.StatusBadRequest)
+			return
+		}
+		u := r.PostForm.Get("username")
+		p := r.PostForm.Get("password")
+		if u != "" && p != "" && checkCreds(c.Users, u, p) {
+			err = runtime.SetSession(w, r, &authsession.AuthSession{
+				Identity: &authsession.Identity{
+					Provider: "Simple",
+					Subject:  u,
+					Name:     u,
+					Email:    "", // simple auth has no email
+				},
+			})
+			if err == nil {
+				runtime.Done(w, r)
+				return
+			}
+		}
+
+		w.WriteHeader(http.StatusForbidden)
+		err = authtemplates.RenderSimpleAuthPage(w, authtemplates.SimpleAuthPage{
+			PostURL:      postURL,
+			ErrorMessage: "Invalid username or password",
+		})
+		if err != nil {
+			logrus.Error(errors.Wrap(err, "failed to render simple auth login page"))
+			return
+		}
+	}
+}

--- a/pkg/authnz/authsession/identity.go
+++ b/pkg/authnz/authsession/identity.go
@@ -12,7 +12,6 @@ type Identity struct {
 	// Email is the email address of the person this Identity refers to.
 	// It may be empty.
 	Email string
-	// Claims are any additional claims that middleware have
-	// added to this Identity.
+	// Claims are any additional claims that middlewares have added to this Identity.
 	Claims Claims
 }

--- a/pkg/authnz/authtemplates/base.go.html
+++ b/pkg/authnz/authtemplates/base.go.html
@@ -1,26 +1,10 @@
-package authtemplates
-
-import (
-	"html/template"
-	"io"
-
-	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authruntime"
-)
-
-type LoginPage struct {
-	Providers []*authruntime.Provider
-}
-
-func RenderLoginPage(w io.Writer, data LoginPage) error {
-	tpl, err := template.New("login-page").Parse(loginPage)
-	if err != nil {
-		return err
-	}
-	return tpl.Execute(w, data)
-}
-
-const loginPage string = `
-<style>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Sign In</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<style>
 	* {
 		font-family: monospace;
 		font-size: 16px;
@@ -58,8 +42,13 @@ const loginPage string = `
 		width: 100%;
 		padding: 10px 15px;
 		border: 1px solid #ccc;
-		color: #ccc;
+		color: #666;
 		box-sizing: border-box;
+	}
+
+	.form label {
+		margin: 10px 0 0;
+		display: block;
 	}
 
 	.form a {
@@ -71,7 +60,7 @@ const loginPage string = `
 	}
 
 	.form > *:last-child {
-		margin-bottom: 0px;
+		margin-bottom: 0;
 	}
 
 	.form input:focus {
@@ -87,6 +76,10 @@ const loginPage string = `
 		border: 0;
 		color: #fff;
 		text-transform: capitalize;
+	}
+
+	.form #submit {
+		margin: 20px 0 0;
 	}
 
 	.form button:hover {
@@ -113,25 +106,13 @@ const loginPage string = `
 		background-color: #4d4d4d;
 		border-radius: 50%;
 	}
-</style>
 
-<section class="form">
-  <h2>Sign In</h2>
-
-	{{range $i, $p := .Providers}}
-		<a href="/signin/{{$i}}">
-			<button>{{$p.Type}}</button>
-		</a>
-	{{end}}
-
-	<!--
-	<form autocomplete="off">
-		<input placeholder="Username" type="text" id="username"></input>
-		<input placeholder="Password" type="password" id="password"></input>
-		<button id="submit">Login</button>
-	</form>
-	<hr />
-	-->
-
-</section>
-`
+	.form .error {
+		color: red;
+	}
+	</style>
+</head>
+<body>
+{{block "body" .}}{{end}}
+</body>
+</html>

--- a/pkg/authnz/authtemplates/login.go.html
+++ b/pkg/authnz/authtemplates/login.go.html
@@ -1,0 +1,13 @@
+{{/*gotype: github.com/freifunkMUC/wg-access-server/pkg/authnz/authtemplates.LoginPage*/ -}}
+{{- define "body" -}}
+<section class="form">
+	<h2>Sign In</h2>
+
+	{{range $i, $p := .Providers}}
+	<a href="/signin/{{$i}}">
+		<button>{{$p.Type}}</button>
+	</a>
+	{{end}}
+
+</section>
+{{- end}}

--- a/pkg/authnz/authtemplates/simpleauth.go.html
+++ b/pkg/authnz/authtemplates/simpleauth.go.html
@@ -1,0 +1,18 @@
+{{/*gotype: github.com/freifunkMUC/wg-access-server/pkg/authnz/authtemplates.SimpleAuthPage*/ -}}
+{{- define "body" -}}
+<section class="form">
+	<h2>Sign In</h2>
+
+	<form action="{{.PostURL}}" method="POST">
+		<label for="username">Username</label>
+		<input type="text" name="username" id="username" required />
+		<label for="password">Password</label>
+		<input type="password" name="password" id="password" autocomplete="current-password" required />
+		<button id="submit" type="submit">Login</button>
+	</form>
+	{{- with .ErrorMessage}}
+	<div class="error">{{.}}</div>
+	{{- end}}
+
+</section>
+{{- end}}

--- a/pkg/authnz/authtemplates/templates.go
+++ b/pkg/authnz/authtemplates/templates.go
@@ -1,0 +1,41 @@
+package authtemplates
+
+import (
+	_ "embed"
+	"html/template"
+	"io"
+
+	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authruntime"
+)
+
+var (
+	//go:embed base.go.html
+	base string
+	//go:embed login.go.html
+	loginPage string
+	//go:embed simpleauth.go.html
+	simpleAuthPage string
+)
+
+var (
+	baseTemplate       = template.Must(template.New("base").Parse(base))
+	loginPageTemplate  = template.Must(template.Must(baseTemplate.Clone()).Parse(loginPage))
+	simpleAuthTemplate = template.Must(template.Must(baseTemplate.Clone()).Parse(simpleAuthPage))
+)
+
+type LoginPage struct {
+	Providers []*authruntime.Provider
+}
+
+func RenderLoginPage(w io.Writer, data LoginPage) error {
+	return loginPageTemplate.Execute(w, data)
+}
+
+type SimpleAuthPage struct {
+	PostURL      string
+	ErrorMessage string
+}
+
+func RenderSimpleAuthPage(w io.Writer, data SimpleAuthPage) error {
+	return simpleAuthTemplate.Execute(w, data)
+}

--- a/pkg/authnz/router.go
+++ b/pkg/authnz/router.go
@@ -42,7 +42,7 @@ func New(config authconfig.AuthConfig, claimsMiddleware authsession.ClaimsMiddle
 
 	router.HandleFunc("/signin", func(w http.ResponseWriter, r *http.Request) {
 		if !config.DesiresSigninPage() && len(providers) == 1 {
-			// we only have one proider, so jump directly to that
+			// we only have one provider, so jump directly to that
 			providers[0].Invoke(w, r, runtime)
 			return
 		}


### PR DESCRIPTION
## Problem
Browsers cache credentials of HTTP Basic Auth. When you click logout, the session cookie of wg-access-server gets reset, however when you click on login again the browser automatically answers the challenge without re-prompting for username and password.
This makes the logout kind of ineffective, which can be a security problem when you or your users have systems where multiple people can access the browser.

According to SO it might be possible to make browsers invalidate their credential cache when you send an XHR request that returns a 401 response. I don't really like that workaround.

## Changes
Instead, I've decided to add a new "simple auth" backend, which works like any other login feature out there.
It has a login form and sends credentials via POST instead of the Basic Auth standard (Authentication header etc.).
The configuration looks exactly the same as the one for basic auth (htpasswd encoded `username:password` pairs).

The admin account now defaults to this backend, unless basic auth is enabled (and simple auth isn't).

The `claimsMiddleware` gave every user with the subject `admin` (or whatever is configured as `adminUsername`) admin privileges. This is now restricted to users from the simple or basic backend, so you can't simply create an admin user in the OIDC provider. Most OIDC systems use numeric identifiers as subject, so this is unlikely to be a problem in reality, but it's a good hardening.

The templating has been redone. The CSS part has been split out into a separate "base" template which is now a full HTML skeleton. Mobile rendering should be improved as well. The `login.go.html` and `simpleauth.go.html` fill in its body block.
All templates are now in their own `*.go.html` files, while allows syntax highlighting in editors/IDEs.
They are embedded into the binary using `//go:embed` directives.

The simple auth login form looks like this:
![simple auth login form](https://user-images.githubusercontent.com/28812678/165312748-e232d3d1-13b3-4b06-a660-ec5f95613145.png)

If anyone has better ideas for the name than "Simple Auth", I'm open for suggestions. 

Fixes #166 