### PR TITLE
Fix missing log entries for ClaimsMiddleware errors

### DIFF
--- a/pkg/authnz/router.go
+++ b/pkg/authnz/router.go
@@ -5,9 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
-	"github.com/pkg/errors"
-
+	"github.com/freifunkMUC/wg-access-server/internal/traces"
 	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authconfig"
 	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authruntime"
 	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authsession"
@@ -16,6 +14,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
+	"github.com/pkg/errors"
 )
 
 type AuthMiddleware struct {
@@ -100,7 +99,7 @@ func (m *AuthMiddleware) Middleware(next http.Handler) http.Handler {
 		if s, err := m.runtime.GetSession(r); err == nil {
 			if m.claimsMiddleware != nil {
 				if err := m.claimsMiddleware(s.Identity); err != nil {
-					ctxlogrus.Extract(r.Context()).Error(errors.Wrap(err, "authz middleware failure"))
+					traces.Logger(r.Context()).Error(errors.Wrap(err, "authz middleware failure"))
 					http.Error(w, "internal server error", http.StatusInternalServerError)
 					return
 				}


### PR DESCRIPTION
## Problem
In `AuthMiddleware.Middleware()` the function tries to log errors using `ctxlogrus`. This logger is a no-op whenever we are handling a non-gRPC request (see #155).
#179 reported a 500 error being returned to clients, without any errors being logged. The missing error log might be caused by the above mentioned problem. The error itself might be a issue of the OIDC provider, but we'll see.

## Changes
Now we use `traces.Logger` instead, which is never a no-op, but still gives us a nice trace id in the log etc.
This should be the last occasion of `ctxlogrus` being used outside of a gRPC context.

Fixes #179 (at least the missing log part, if something else is broken on our side we'll reopen it)