### PR TITLE
Remove reference to nonexistent manifest.json

### DIFF
--- a/website/public/index.html
+++ b/website/public/index.html
@@ -9,11 +9,6 @@
   <meta name="description" content="Website for the wg-access-server" />
   <link rel="apple-touch-icon" href="logo-192.png" />
   <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.


### PR DESCRIPTION
There is no manifest.json in the repository, nor is it generated during build or dynamically on requests.
#203 reported that it causes CORS issues, while I haven't confirmed whether these issues exist and whether they are fixed by removing it, a reference to a nonexistent file shouldn't be there anyway.

Fixes #203 