### PR TITLE
Fix GH Pages docs build

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
-markdown-include==0.6.0
-mkdocs==1.2.3
-mkdocs-material==8.1.5
-pygments~=2.11.2
-pymdown-extensions==9.1
+markdown-include~=0.6.0
+mkdocs~=1.3.0
+mkdocs-material~=8.3.8
+pygments~=2.12.0
+pymdown-extensions~=9.5


### PR DESCRIPTION
## Problem
The documentation fails to build for GitHub pages, see #210 

Looks like Jinja2 hat breaking changes it version 3.1.0 (because who cares about semver, right?) which affected mkdocs.
Fortunately mkdocs has taken care of it in release 1.2.4: https://www.mkdocs.org/about/release-notes/#version-124-2022-03-26

## Changes
Upgrade the docs requirements to their latest versions, most importantly mkdocs from 1.2.3 to 1.3.0.
I've also changed all version specifiers to `~=`, which also allows releases with same MAJOR.MINOR but higher BUILD number.

Fixes #210 