### PR TITLE
Add option to read claims from OIDC ID Token

### DIFF
--- a/docs/4-auth.md
+++ b/docs/4-auth.md
@@ -59,26 +59,34 @@ auth:
     # Your OIDC client credentials which would be provided by your OIDC provider
     clientID: "<client-id>"
     clientSecret: "<client-secret>"
-    # List of scopes to request defaults to ["openid"]
-    scopes:
-      - openid
     # The full redirect URL
     # The path can be almost anything as long as it doesn't
     # conflict with a path that the web UI uses.
     # /callback is recommended.
     redirectURL: "https://wg-access-server.example.com/callback"
+    # List of scopes to request claims for. Must include 'openid'.
+    # Must include 'email' if 'emailDomains' is used. Can include 'profile' to show the user's name in the UI.
+    # Add custom ones if required for 'claimMapping'.
+    # Defaults to ["openid"]
+    scopes:
+      - openid
+      - profile
+      - email
     # You can optionally restrict access to users with an email address
     # that matches an allowed domain.
     # If empty or omitted then all email domains will be allowed.
     emailDomains:
       - example.com
-    # This is an advanced feature that allows you to define
-    # OIDC claim mapping expressions.
-    # This feature is used to define wg-access-server admins
-    # based off a claim in your OIDC token
-    # See https://github.com/Knetic/govaluate/blob/9aa49832a739dcd78a5542ff189fb82c3e423116/MANUAL.md for how to write rules
+    # This is an advanced feature that allows you to define OIDC claim mapping expressions.
+    # This feature is used to define wg-access-server admins based off a claim in your OIDC token.
+    # A JSON-like object of claimKey: claimValue pairs as returned by the issuer is passed to the evaluation function. 
+    # See https://github.com/Knetic/govaluate/blob/9aa49832a739dcd78a5542ff189fb82c3e423116/MANUAL.md for the syntax.
     claimMapping:
+      # This example works if you have a custom group_membership claim which is a list of strings 
       admin: "'WireguardAdmins' in group_membership"
+    # Let wg-access-server retrieve the claims from the ID Token instead of querying the UserInfo endpoint.
+    # Some OIDC authorization provider implementations (e.g. ADFS) only publish claims in the ID Token.
+    claimsFromIDToken: false
   gitlab:
     name: "My Gitlab Backend"
     baseURL: "https://mygitlab.example.com"
@@ -88,3 +96,9 @@ auth:
     emailDomains:
       - example.com
 ```
+
+## OIDC Provider specifics
+
+### Active Directory Federation Services (ADFS)
+
+Please see [this helpful issue comment](https://github.com/freifunkMUC/wg-access-server/issues/213#issuecomment-1172656633) for instructions for ADFS 2016 and above.

--- a/pkg/authnz/authconfig/oidc_test.go
+++ b/pkg/authnz/authconfig/oidc_test.go
@@ -1,0 +1,46 @@
+package authconfig
+
+import (
+	"reflect"
+	"testing"
+
+	"gopkg.in/Knetic/govaluate.v2"
+
+	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authsession"
+)
+
+func Test_evaluateClaimMapping(t *testing.T) {
+	type args struct {
+		claimMapping map[string]ruleExpression
+		oidcClaims   map[string]interface{}
+	}
+
+	expr, _ := govaluate.NewEvaluableExpression("'WireguardAdmins' in group_membership")
+
+	tests := []struct {
+		name    string
+		args    args
+		want    authsession.Claims
+		wantErr bool
+	}{
+		{
+			args: args{
+				claimMapping: map[string]ruleExpression{"admin": {expr}},
+				oidcClaims:   map[string]interface{}{"group_membership": []interface{}{"wgas", "WireguardAdmins"}},
+			},
+			want: authsession.Claims{{Name: "admin", Value: "true"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := evaluateClaimMapping(tt.args.claimMapping, tt.args.oidcClaims)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("evaluateClaimMapping() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(*got, tt.want) {
+				t.Errorf("evaluateClaimMapping() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/authnz/authruntime/runtime.go
+++ b/pkg/authnz/authruntime/runtime.go
@@ -36,7 +36,7 @@ func (p *ProviderRuntime) ClearSession(w http.ResponseWriter, r *http.Request) e
 }
 
 func (p *ProviderRuntime) Restart(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/signin", http.StatusTemporaryRedirect)
+	http.Redirect(w, r, "/signin?signout=1", http.StatusTemporaryRedirect)
 }
 
 func (p *ProviderRuntime) Done(w http.ResponseWriter, r *http.Request) {

--- a/pkg/authnz/authutil/random.go
+++ b/pkg/authnz/authutil/random.go
@@ -8,11 +8,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// RandomString returns a base64url-encoded string of random data of size bytes
 func RandomString(size int) string {
 	blk := make([]byte, size)
 	_, err := rand.Read(blk)
 	if err != nil {
 		logrus.Fatal(errors.Wrap(err, "failed to make a random string"))
 	}
-	return base64.StdEncoding.EncodeToString(blk)
+	return base64.URLEncoding.EncodeToString(blk)
 }

--- a/pkg/authnz/router.go
+++ b/pkg/authnz/router.go
@@ -40,7 +40,7 @@ func New(config authconfig.AuthConfig, claimsMiddleware authsession.ClaimsMiddle
 	}
 
 	router.HandleFunc("/signin", func(w http.ResponseWriter, r *http.Request) {
-		if !config.DesiresSigninPage() && len(providers) == 1 {
+		if r.FormValue("signout") != "1" && !config.DesiresSigninPage() && len(providers) == 1 {
 			// we only have one provider, so jump directly to that
 			providers[0].Invoke(w, r, runtime)
 			return


### PR DESCRIPTION
This allows reading OIDC claims from the ID Token instead of querying the UserInfo endpoint. Both methods are valid, however some OIDC auth providers like ADFS do not support the UserInfo endpoint:

> The AD FS UserInfo endpoint always returns the subject claim as specified in the OpenID standards. AD FS doesn't support additional claims requested via the UserInfo endpoint.

https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/overview/ad-fs-faq#i-m-trying-to-get-more-claims-on-the-userinfo-endpoint--but-it-s-only-returning-subject--how-can-i-get-more-claims-

Querying the UserInfo endpoint might however return more up to date data, so we still default to it.

## Changes

A new `claimsFromIDToken` option has been added to the OIDC config. It defaults to false, setting it to true makes wgas parse claims from the ID token instead of querying the `/userinfo` endpoint of the provider.

I've also taken the opportunity to put some documentation into the OIDC code, so it's easier to understand and compare with the OIDC flow.

We now use an url-safe variant of base64 to encode the `state` nonce, which may or may not help with buggy OIDC providers.

After logging out, it now always shows the sign-in page, even if only one auth provider is configured. This prevents automatically redirecting to the OIDC provider and logging right back in again, basically making logout functionality not work.
Note however that this still doesn't log your out from the actual OIDC auth provider, so anyone with access to the browser could log back in just by opening the wg-access-server page again, without having to enter a password again.


Closes #213 