### PR TITLE
Removed: Gitleaks action

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,15 +8,6 @@ on:
   pull_request:
 
 jobs: # Docs: <https://git.io/JvxXE>
-  gitleaks:
-    name: Gitleaks
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-        with: {fetch-depth: 0}
-
-      - uses: zricethezav/gitleaks-action@v1 # Action page: <https://github.com/zricethezav/gitleaks-action>
-
   golangci-lint:
     name: Golang-CI (lint)
     runs-on: ubuntu-20.04


### PR DESCRIPTION
as it now requires a commercial license