### PR TITLE
Require claim to be present to allow access to the user

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -370,7 +370,7 @@ func claimsMiddleware(conf *config.AppConfig) authsession.ClaimsMiddleware {
 			user.Claims.Add("admin", "true")
 		}
 		// allow access to users only when access claim is present for OIDC
-		if user.Provider == conf.Auth.OIDC.Name && conf.Auth.OIDC.AccessClaim != "" {
+		if conf.Auth.OIDC != nil && user.Provider == conf.Auth.OIDC.Name && conf.Auth.OIDC.AccessClaim != "" {
 			if !user.Claims.Has(conf.Auth.OIDC.AccessClaim, "true") {
 				return errors.New("User has no access")
 			}

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -369,6 +369,13 @@ func claimsMiddleware(conf *config.AppConfig) authsession.ClaimsMiddleware {
 		if (user.Provider == "Basic" || user.Provider == "Simple") && user.Subject == conf.AdminUsername {
 			user.Claims.Add("admin", "true")
 		}
+		// allow access to users only when access claim is present for OIDC
+		if user.Provider == conf.Auth.OIDC.Name && conf.Auth.OIDC.AccessClaim != "" {
+			if !user.Claims.Has(conf.Auth.OIDC.AccessClaim, "true") {
+				return errors.New("User has no access")
+			}
+		}
+
 		return nil
 	}
 }

--- a/docs/4-auth.md
+++ b/docs/4-auth.md
@@ -84,9 +84,12 @@ auth:
     claimMapping:
       # This example works if you have a custom group_membership claim which is a list of strings 
       admin: "'WireguardAdmins' in group_membership"
+      access: "'WireguardAccess' in group_membership"
     # Let wg-access-server retrieve the claims from the ID Token instead of querying the UserInfo endpoint.
     # Some OIDC authorization provider implementations (e.g. ADFS) only publish claims in the ID Token.
     claimsFromIDToken: false
+    # require this claim to be "true" to allow access for the user
+    accessClaim: "access"
   gitlab:
     name: "My Gitlab Backend"
     baseURL: "https://mygitlab.example.com"

--- a/pkg/authnz/authconfig/oidc.go
+++ b/pkg/authnz/authconfig/oidc.go
@@ -32,6 +32,7 @@ type OIDCConfig struct {
 	EmailDomains      []string                  `yaml:"emailDomains"`
 	ClaimMapping      map[string]ruleExpression `yaml:"claimMapping"`
 	ClaimsFromIDToken bool                      `yaml:"claimsFromIDToken"`
+	AccessClaim       string                    `yaml:"accessClaim"`
 }
 
 func (c *OIDCConfig) Provider() *authruntime.Provider {


### PR DESCRIPTION
This PR should allow admin to require OIDC claim to be present for user to be able to access wg-access-server.

Closes #200 