### PR TITLE
feat: specify stable session cookie secret for HA setup

### DIFF
--- a/docs/4-auth.md
+++ b/docs/4-auth.md
@@ -41,10 +41,9 @@ adminUsername: "admin"
 # Configure zero or more authentication backends
 auth:
   sessionStore:
-    # 32 random bytes used to sign session cookies. It's generated randomly
+    # 32 random bytes in hexadecimal encoding (64 chars) used to sign session cookies. It's generated randomly
     # if not present. Need to be set when running in HA setup (more than one replica)
-    # It has to be 32 bytes long (/[0-9a-f]{64}/)
-    secret: 4f68646565736f6f5368346f685468656567364c696537636569746861696368
+    secret: "<session store secret>"
   simple:
     # Users is a list of htpasswd encoded username:password pairs
     # supports BCrypt, Sha, Ssha, Md5

--- a/docs/4-auth.md
+++ b/docs/4-auth.md
@@ -40,6 +40,11 @@ adminPassword: "<admin password>"
 adminUsername: "admin"
 # Configure zero or more authentication backends
 auth:
+  sessionStore:
+    # 32 random bytes used to sign session cookies. It's generated randomly
+    # if not present. Need to be set when running in HA setup (more than one replica)
+    # It has to be 32 bytes long (/[0-9a-f]{64}/)
+    secret: 4f68646565736f6f5368346f685468656567364c696537636569746861696368
   simple:
     # Users is a list of htpasswd encoded username:password pairs
     # supports BCrypt, Sha, Ssha, Md5

--- a/pkg/authnz/authconfig/authconfig.go
+++ b/pkg/authnz/authconfig/authconfig.go
@@ -5,10 +5,15 @@ import (
 )
 
 type AuthConfig struct {
-	OIDC   *OIDCConfig       `yaml:"oidc"`
-	Gitlab *GitlabConfig     `yaml:"gitlab"`
-	Basic  *BasicAuthConfig  `yaml:"basic"`
-	Simple *SimpleAuthConfig `yaml:"simple"`
+	SessionStore *SessionStoreConfig `yaml:"sessionStore"`
+	OIDC         *OIDCConfig         `yaml:"oidc"`
+	Gitlab       *GitlabConfig       `yaml:"gitlab"`
+	Basic        *BasicAuthConfig    `yaml:"basic"`
+	Simple       *SimpleAuthConfig   `yaml:"simple"`
+}
+
+type SessionStoreConfig struct {
+	Secret string `yaml:"secret"`
 }
 
 func (c *AuthConfig) IsEnabled() bool {


### PR DESCRIPTION
When running multiple replicas in kubernetes users are getting "no session" error when trying to authenticate. It's caused by random session cookie secret generated differently for each POD.