### PR TITLE
Fix nil pointer dereference without SessionStore config

### DIFF
--- a/pkg/authnz/router.go
+++ b/pkg/authnz/router.go
@@ -28,7 +28,7 @@ type AuthMiddleware struct {
 func New(config authconfig.AuthConfig, claimsMiddleware authsession.ClaimsMiddleware) (*AuthMiddleware, error) {
 	router := mux.NewRouter()
 	var storeSecret []byte
-	if config.SessionStore.Secret == "" {
+	if config.SessionStore == nil || config.SessionStore.Secret == "" {
 		storeSecret = []byte(authutil.RandomString(32))
 	} else {
 		var err error


### PR DESCRIPTION
Fixup of #263 

Similar error to https://github.com/freifunkMUC/wg-access-server/pull/259#discussion_r1014868820, unfortunately I missed this one.

If `sessionStore` isn't specified at all in the config, `AuthConfig.SesstionStore` is `nil` (as it is a pointer), and needs to be checked for nil-ness first before accessing its member `Secret`.