### PR TITLE
Bring your own public key

### DIFF
--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -3,6 +3,7 @@ package devices
 import (
 	"fmt"
 	"net/netip"
+	"regexp"
 	"sync"
 	"time"
 
@@ -25,6 +26,9 @@ type DeviceManager struct {
 type User struct {
 	Name string
 }
+
+// https://lists.zx2c4.com/pipermail/wireguard/2020-December/006222.html
+var regex = regexp.MustCompile("^[A-Za-z0-9+/]{42}[A|E|I|M|Q|U|Y|c|g|k|o|s|w|4|8|0]=$")
 
 func New(wg wgembed.WireGuardInterface, s storage.Storage, cidr, cidrv6 string) *DeviceManager {
 	return &DeviceManager{wg, s, cidr, cidrv6}
@@ -88,6 +92,10 @@ func (d *DeviceManager) AddDevice(identity *authsession.Identity, name string, p
 
 	if nameTaken {
 		return nil, errors.New("device name already taken")
+	}
+
+	if !regex.MatchString(publicKey) {
+		return nil, errors.New("public key has invalid format")
 	}
 
 	clientAddr, err := d.nextClientAddress()

--- a/internal/services/device_service.go
+++ b/internal/services/device_service.go
@@ -3,15 +3,15 @@ package services
 import (
 	"context"
 
-	"github.com/freifunkMUC/wg-access-server/internal/devices"
-	"github.com/freifunkMUC/wg-access-server/internal/storage"
-	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authsession"
-	"github.com/freifunkMUC/wg-access-server/proto/proto"
-
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/freifunkMUC/wg-access-server/internal/devices"
+	"github.com/freifunkMUC/wg-access-server/internal/storage"
+	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authsession"
+	"github.com/freifunkMUC/wg-access-server/proto/proto"
 )
 
 type DeviceService struct {
@@ -28,7 +28,7 @@ func (d *DeviceService) AddDevice(ctx context.Context, req *proto.AddDeviceReq) 
 	device, err := d.DeviceManager.AddDevice(user, req.GetName(), req.GetPublicKey())
 	if err != nil {
 		ctxlogrus.Extract(ctx).Error(err)
-		return nil, status.Errorf(codes.Internal, "failed to add device")
+		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
 	return mapDevice(device), nil

--- a/website/src/components/AddDevice.tsx
+++ b/website/src/components/AddDevice.tsx
@@ -13,7 +13,7 @@ import InputLabel from '@material-ui/core/InputLabel';
 import Typography from '@material-ui/core/Typography';
 import AddIcon from '@material-ui/icons/Add';
 import { codeBlock } from 'common-tags';
-import { observable, makeObservable } from 'mobx';
+import { makeObservable, observable } from 'mobx';
 import { observer } from 'mobx-react';
 import React from 'react';
 import { box_keyPair } from 'tweetnacl-ts';
@@ -33,13 +33,15 @@ export const AddDevice = observer(class AddDevice extends React.Component<Props>
 
   deviceName = '';
 
+  devicePublickey = '';
+
   configFile?: string;
 
   submit = async (event: React.FormEvent) => {
     event.preventDefault();
 
     const keypair = box_keyPair();
-    const publicKey = window.btoa(String.fromCharCode(...(new Uint8Array(keypair.publicKey) as any)));
+    const publicKey = this.devicePublickey || window.btoa(String.fromCharCode(...(new Uint8Array(keypair.publicKey) as any)));
     const privateKey = window.btoa(String.fromCharCode(...(new Uint8Array(keypair.secretKey) as any)));
 
     try {
@@ -68,12 +70,14 @@ export const AddDevice = observer(class AddDevice extends React.Component<Props>
     } catch (error) {
       console.log(error);
       // TODO: unwrap grpc error message
-      this.error = 'failed';
+      this.error = 'failed to add device';;
     }
   };
 
   reset = () => {
     this.deviceName = '';
+    this.devicePublickey = '';
+    this.error = '';
   };
 
   constructor(props: Props) {
@@ -83,6 +87,7 @@ export const AddDevice = observer(class AddDevice extends React.Component<Props>
       dialogOpen: observable,
       error: observable,
       deviceName: observable,
+      devicePublickey: observable,
       configFile: observable
     });
   }
@@ -94,7 +99,7 @@ export const AddDevice = observer(class AddDevice extends React.Component<Props>
           <CardHeader title="Add A Device" />
           <CardContent>
             <form onSubmit={this.submit}>
-              <FormControl error={!!this.error} fullWidth>
+              <FormControl fullWidth>
                 <InputLabel htmlFor="device-name">Device Name</InputLabel>
                 <Input
                   id="device-name"
@@ -102,8 +107,19 @@ export const AddDevice = observer(class AddDevice extends React.Component<Props>
                   onChange={(event) => (this.deviceName = event.currentTarget.value)}
                   aria-describedby="device-name-text"
                 />
-                <FormHelperText id="device-name-text">{this.error}</FormHelperText>
+                <FormHelperText id="device-name-text">Any name to your liking</FormHelperText>
               </FormControl>
+              <FormControl fullWidth>
+                <InputLabel htmlFor="device-publickey">Device Public Key</InputLabel>
+                <Input
+                  id="device-publickey"
+                  value={this.devicePublickey}
+                  onChange={(event) => (this.devicePublickey = event.currentTarget.value)}
+                  aria-describedby="device-publickey-text"
+                />
+                <FormHelperText id="device-publickey-text">You may extract your public key from your given private key with: wg pubkey &lt; private.key</FormHelperText>
+              </FormControl>
+              <FormHelperText id="device-error-text" error={true}>{this.error}</FormHelperText>
               <Typography component="div" align="right">
                 <Button color="secondary" type="button" onClick={this.reset}>
                   Cancel

--- a/website/src/components/AddDevice.tsx
+++ b/website/src/components/AddDevice.tsx
@@ -37,6 +37,8 @@ export const AddDevice = observer(class AddDevice extends React.Component<Props>
 
   configFile?: string;
 
+  showMobile = true;
+
   submit = async (event: React.FormEvent) => {
     event.preventDefault();
 
@@ -46,9 +48,11 @@ export const AddDevice = observer(class AddDevice extends React.Component<Props>
     if (this.devicePublickey) {
       publicKey = this.devicePublickey
       privateKey = 'pleaseReplaceThisPrivatekey'
+      this.showMobile = false;
     } else {
       publicKey = window.btoa(String.fromCharCode(...(new Uint8Array(keypair.publicKey) as any)));
       privateKey = window.btoa(String.fromCharCode(...(new Uint8Array(keypair.secretKey) as any)));
+      this.showMobile = true;
     }
 
     try {
@@ -95,7 +99,8 @@ export const AddDevice = observer(class AddDevice extends React.Component<Props>
       error: observable,
       deviceName: observable,
       devicePublickey: observable,
-      configFile: observable
+      configFile: observable,
+      showMobile: observable
     });
   }
 
@@ -155,7 +160,7 @@ export const AddDevice = observer(class AddDevice extends React.Component<Props>
             </Info>
           </DialogTitle>
           <DialogContent>
-            <GetConnected configFile={this.configFile!} />
+            <GetConnected configFile={this.configFile!} showMobile={this.showMobile}/>
           </DialogContent>
           <DialogActions>
             <Button color="secondary" variant="outlined" onClick={() => (this.dialogOpen = false)}>

--- a/website/src/components/AddDevice.tsx
+++ b/website/src/components/AddDevice.tsx
@@ -41,8 +41,15 @@ export const AddDevice = observer(class AddDevice extends React.Component<Props>
     event.preventDefault();
 
     const keypair = box_keyPair();
-    const publicKey = this.devicePublickey || window.btoa(String.fromCharCode(...(new Uint8Array(keypair.publicKey) as any)));
-    const privateKey = window.btoa(String.fromCharCode(...(new Uint8Array(keypair.secretKey) as any)));
+    var publicKey: string;
+    var privateKey: string;
+    if (this.devicePublickey) {
+      publicKey = this.devicePublickey
+      privateKey = 'pleaseReplaceThisPrivatekey'
+    } else {
+      publicKey = window.btoa(String.fromCharCode(...(new Uint8Array(keypair.publicKey) as any)));
+      privateKey = window.btoa(String.fromCharCode(...(new Uint8Array(keypair.secretKey) as any)));
+    }
 
     try {
       const device = await grpc.devices.addDevice({
@@ -107,17 +114,16 @@ export const AddDevice = observer(class AddDevice extends React.Component<Props>
                   onChange={(event) => (this.deviceName = event.currentTarget.value)}
                   aria-describedby="device-name-text"
                 />
-                <FormHelperText id="device-name-text">Any name to your liking</FormHelperText>
               </FormControl>
               <FormControl fullWidth>
-                <InputLabel htmlFor="device-publickey">Device Public Key</InputLabel>
+                <InputLabel htmlFor="device-publickey">Device Public Key (Optional)</InputLabel>
                 <Input
                   id="device-publickey"
                   value={this.devicePublickey}
                   onChange={(event) => (this.devicePublickey = event.currentTarget.value)}
                   aria-describedby="device-publickey-text"
                 />
-                <FormHelperText id="device-publickey-text">You may extract your public key from your given private key with: wg pubkey &lt; private.key</FormHelperText>
+                <FormHelperText id="device-publickey-text">Put your public key to a pre-generated private key here. Replace the private key in the config file after downloading it.</FormHelperText>
               </FormControl>
               <FormHelperText id="device-error-text" error={true}>{this.error}</FormHelperText>
               <Typography component="div" align="right">

--- a/website/src/components/GetConnected.tsx
+++ b/website/src/components/GetConnected.tsx
@@ -20,11 +20,12 @@ import { TabPanel } from './TabPanel';
 
 interface Props {
   configFile: string;
+  showMobile: boolean;
 }
 
 export class GetConnected extends React.Component<Props> {
   state = {
-    currentTab: isMobile() ? 'mobile' : 'desktop',
+    currentTab: isMobile() && this.props.showMobile ? 'mobile' : 'desktop',
   };
 
   go = (href: string) => {
@@ -55,7 +56,9 @@ export class GetConnected extends React.Component<Props> {
             variant="fullWidth"
           >
             <Tab icon={<Laptop />} value="desktop" />
+            {this.props.showMobile && 
             <Tab icon={<PhoneIphone />} value="mobile" />
+            }
           </Tabs>
         </Paper>
 
@@ -91,6 +94,7 @@ export class GetConnected extends React.Component<Props> {
           </Grid>
         </TabPanel>
 
+        {this.props.showMobile && 
         <TabPanel for="mobile" value={this.state.currentTab}>
           <Grid container direction="row" justify="space-around" alignItems="center">
             <Grid item>
@@ -111,6 +115,7 @@ export class GetConnected extends React.Component<Props> {
             </Grid>
           </Grid>
         </TabPanel>
+        }
       </React.Fragment>
     );
   }


### PR DESCRIPTION
Hi,

This is a PR in a serie of 6 PRs, as it was asked to split https://github.com/freifunkMUC/wg-access-server/pull/294 up into multiple PRs.

**Serie:**

* **(THIS PR)** feature/bring-your-own-public-key
* feature/remove-all-devices-for-user
* feature/purge-inactive-devices
* feature/health-check
* hygiene/put-common-auth-logic-into-func
* feature/pre-shared-keys 

**Feature:**

This feature extends the wg-access-server, enabling the user to bring its own public key, instead of it being generated by the frontend. Reason for this is that the private key (generated in the browser), should in some circumstance not touch the web in any way.

This adds a new form input to "Add Device":

![2023:02:07-144943](https://user-images.githubusercontent.com/48495685/217263727-237baf4d-aec5-4eb7-a8e8-a71a000b2d24.png)

