### PR TITLE
health check

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -13,16 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/freifunkMUC/wg-access-server/internal/config"
-	"github.com/freifunkMUC/wg-access-server/internal/devices"
-	"github.com/freifunkMUC/wg-access-server/internal/dnsproxy"
-	"github.com/freifunkMUC/wg-access-server/internal/network"
-	"github.com/freifunkMUC/wg-access-server/internal/services"
-	"github.com/freifunkMUC/wg-access-server/internal/storage"
-	"github.com/freifunkMUC/wg-access-server/pkg/authnz"
-	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authconfig"
-	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authsession"
-
 	"github.com/docker/libnetwork/resolvconf"
 	"github.com/docker/libnetwork/types"
 	"github.com/freifunkMUC/wg-embed/pkg/wgembed"
@@ -34,6 +24,16 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/yaml.v2"
+
+	"github.com/freifunkMUC/wg-access-server/internal/config"
+	"github.com/freifunkMUC/wg-access-server/internal/devices"
+	"github.com/freifunkMUC/wg-access-server/internal/dnsproxy"
+	"github.com/freifunkMUC/wg-access-server/internal/network"
+	"github.com/freifunkMUC/wg-access-server/internal/services"
+	"github.com/freifunkMUC/wg-access-server/internal/storage"
+	"github.com/freifunkMUC/wg-access-server/pkg/authnz"
+	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authconfig"
+	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authsession"
 )
 
 func Register(app *kingpin.Application) *servecmd {
@@ -222,7 +222,7 @@ func (cmd *servecmd) Run() {
 	router.Use(services.RecoveryMiddleware)
 
 	// Health check endpoint
-	router.PathPrefix("/health").Handler(services.HealthEndpoint())
+	router.PathPrefix("/health").Handler(services.HealthEndpoint(deviceManager))
 
 	// Authentication middleware
 	middleware, err := authnz.NewMiddleware(conf.Auth, claimsMiddleware(conf))

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/docker/libnetwork v0.8.0-dev.2.0.20200217033114-6659f7f4d8c1
 	github.com/freifunkMUC/pg-events v0.4.1
-	github.com/freifunkMUC/wg-embed v0.8.0
+	github.com/freifunkMUC/wg-embed v0.9.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
@@ -67,7 +67,7 @@ require (
 	golang.zx2c4.com/wireguard v0.0.0-20220601130007-6a08d81f6bc4 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	gopkg.in/ini.v1 v1.66.6 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools v2.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVB
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/freifunkMUC/pg-events v0.4.1 h1:e+Zkj6Q5C5Owzt5iC2CO7/i0NBzjK1wzJ7CV9qItHeI=
 github.com/freifunkMUC/pg-events v0.4.1/go.mod h1:ShsE9Hlb3h2gfBN+CkoZMmSMizwYIk30A9fZBfeNoZ0=
-github.com/freifunkMUC/wg-embed v0.8.0 h1:VVXm3DCEIwPEL7bvBJxwevhMlmydPCaLJ7b6oyW3Bgg=
-github.com/freifunkMUC/wg-embed v0.8.0/go.mod h1:WXz6XErQMHhjZblJMYxg16a+i9JnvscmgmrRz34iH2I=
+github.com/freifunkMUC/wg-embed v0.9.0 h1:qFebEzSW1h8r6dThZSgr9zKVBzcBETOPecfGKfGHnG0=
+github.com/freifunkMUC/wg-embed v0.9.0/go.mod h1:SK+QqRByh0TJFOwTc6y8llbo/bthIIcCc+DY9LHQWR8=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
@@ -648,8 +648,8 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.29.1/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
-gopkg.in/ini.v1 v1.66.6 h1:LATuAqN/shcYAOkv3wl2L4rkaKqkcgTBQjOyYDvcPKI=
-gopkg.in/ini.v1 v1.66.6/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
+gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
 gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -38,7 +38,7 @@ func (d *DeviceManager) StartSync(disableMetadataCollection, disableInactiveDevi
 	// Start listening to the device add/remove events
 	d.storage.OnAdd(func(device *storage.Device) {
 		logrus.Debugf("storage event: device added: %s/%s", device.Owner, device.Name)
-		if err := d.wg.AddPeer(device.PublicKey, network.SplitAddresses(device.Address)); err != nil {
+		if err := d.wg.AddPeer(device.PublicKey, "", network.SplitAddresses(device.Address)); err != nil {
 			logrus.Error(errors.Wrap(err, "failed to add wireguard peer"))
 		}
 	})
@@ -151,7 +151,7 @@ func (d *DeviceManager) sync() error {
 
 	// Add peers for all devices in storage
 	for _, device := range devices {
-		if err := d.wg.AddPeer(device.PublicKey, network.SplitAddresses(device.Address)); err != nil {
+		if err := d.wg.AddPeer(device.PublicKey, "", network.SplitAddresses(device.Address)); err != nil {
 			logrus.Warn(errors.Wrapf(err, "failed to add device during sync: %s", device.Name))
 		}
 	}

--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -316,7 +316,9 @@ func (d *DeviceManager) Ping() error {
 		return errors.Wrap(err, "failed to ping storage")
 	}
 
-	// TODO ping wireguard
+	if err := d.wg.Ping(); err != nil {
+		return errors.Wrap(err, "failed to ping wireguard")
+	}
 
 	return nil
 }

--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -311,6 +311,16 @@ func (d *DeviceManager) DeleteDevicesForUser(user string) error {
 	return nil
 }
 
+func (d *DeviceManager) Ping() error {
+	if err := d.storage.Ping(); err != nil {
+		return errors.Wrap(err, "failed to ping storage")
+	}
+
+	// TODO ping wireguard
+
+	return nil
+}
+
 func IsConnected(lastHandshake time.Time) bool {
 	return lastHandshake.After(time.Now().Add(-3 * time.Minute))
 }

--- a/internal/services/health.go
+++ b/internal/services/health.go
@@ -3,11 +3,18 @@ package services
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/freifunkMUC/wg-access-server/internal/devices"
 )
 
-func HealthEndpoint() http.Handler {
+func HealthEndpoint(d *devices.DeviceManager) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
+		if err := d.Ping(); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "ping failed")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, "ok")
 	})
 }

--- a/internal/storage/contracts.go
+++ b/internal/storage/contracts.go
@@ -11,6 +11,7 @@ import (
 
 type Storage interface {
 	Watcher
+	Pingable
 	Save(device *Device) error
 	List(owner string) ([]*Device, error)
 	Get(owner string, name string) (*Device, error)
@@ -26,6 +27,10 @@ type Watcher interface {
 	OnReconnect(func())
 	EmitAdd(device *Device)
 	EmitDelete(device *Device)
+}
+
+type Pingable interface {
+	Ping() error
 }
 
 type Callback func(device *Device)

--- a/internal/storage/inmemory.go
+++ b/internal/storage/inmemory.go
@@ -75,3 +75,7 @@ func (s *InMemoryStorage) Delete(device *Device) error {
 	s.EmitDelete(device)
 	return nil
 }
+
+func (s *InMemoryStorage) Ping() error {
+	return nil
+}

--- a/internal/storage/sql.go
+++ b/internal/storage/sql.go
@@ -188,3 +188,15 @@ func (s *SQLStorage) Delete(device *Device) error {
 	s.Watcher.EmitDelete(device)
 	return nil
 }
+
+func (s *SQLStorage) Ping() error {
+	db := s.db.DB()
+	if db == nil {
+		return errors.New("failed to get db")
+	}
+
+	if err := db.Ping(); err != nil {
+		return errors.Wrap(err, "failed to ping db")
+	}
+	return nil
+}


### PR DESCRIPTION
Hi,

This is a PR in a serie of 6 PRs, as it was asked to split https://github.com/freifunkMUC/wg-access-server/pull/294 up into multiple PRs.

**Serie:**

* feature/bring-your-own-public-key
* feature/remove-all-devices-for-user
* feature/purge-inactive-devices
* **(THIS PR)** feature/health-check
* hygiene/put-common-auth-logic-into-func
* feature/pre-shared-keys 

**Dependency**

This PR depends on https://github.com/freifunkMUC/wg-embed/pull/15 and **its version has to be updated before this PR can be merged**.

**Feature:**

This feature extends the wg-access-server with proper health checks. It pings the embedded wireguard and the storage backend.

closes: https://github.com/freifunkMUC/wg-access-server/issues/100