### PR TITLE
put common auth logic into func

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -33,7 +33,6 @@ import (
 	"github.com/freifunkMUC/wg-access-server/internal/storage"
 	"github.com/freifunkMUC/wg-access-server/pkg/authnz"
 	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authconfig"
-	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authsession"
 )
 
 func Register(app *kingpin.Application) *servecmd {
@@ -225,7 +224,7 @@ func (cmd *servecmd) Run() {
 	router.PathPrefix("/health").Handler(services.HealthEndpoint(deviceManager))
 
 	// Authentication middleware
-	middleware, err := authnz.NewMiddleware(conf.Auth, claimsMiddleware(conf))
+	middleware, err := authnz.NewMiddleware(conf.Auth, authnz.ClaimsMiddleware(conf))
 	if err != nil {
 		logrus.Error(errors.Wrap(err, "failed to set up authnz middleware"))
 		return
@@ -360,26 +359,6 @@ func (cmd *servecmd) ReadConfig() *config.AppConfig {
 	}
 
 	return &cmd.AppConfig
-}
-
-func claimsMiddleware(conf *config.AppConfig) authsession.ClaimsMiddleware {
-	return func(user *authsession.Identity) error {
-		if user == nil {
-			return errors.New("User is not logged in")
-		}
-		// restrict privilege elevation by username to basic and simple auth users only
-		if (user.Provider == authconfig.BasicAuthProvider || user.Provider == authconfig.SimpleAuthProvider) && user.Subject == conf.AdminUsername {
-			user.Claims.MakeAdmin()
-		}
-		// allow access to users only when access claim is present for OIDC
-		if conf.Auth.OIDC != nil && user.Provider == conf.Auth.OIDC.Name && conf.Auth.OIDC.AccessClaim != "" {
-			if !user.Claims.Has(conf.Auth.OIDC.AccessClaim, "true") {
-				return errors.New("User has no access")
-			}
-		}
-
-		return nil
-	}
 }
 
 func detectDNSUpstream(ipv4Enabled, ipv6Enabled bool) []string {

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -368,8 +368,8 @@ func claimsMiddleware(conf *config.AppConfig) authsession.ClaimsMiddleware {
 			return errors.New("User is not logged in")
 		}
 		// restrict privilege elevation by username to basic and simple auth users only
-		if (user.Provider == "Basic" || user.Provider == "Simple") && user.Subject == conf.AdminUsername {
-			user.Claims.Add("admin", "true")
+		if (user.Provider == authconfig.BasicAuthProvider || user.Provider == authconfig.SimpleAuthProvider) && user.Subject == conf.AdminUsername {
+			user.Claims.MakeAdmin()
 		}
 		// allow access to users only when access claim is present for OIDC
 		if conf.Auth.OIDC != nil && user.Provider == conf.Auth.OIDC.Name && conf.Auth.OIDC.AccessClaim != "" {

--- a/internal/services/device_service.go
+++ b/internal/services/device_service.go
@@ -59,7 +59,7 @@ func (d *DeviceService) DeleteDevice(ctx context.Context, req *proto.DeleteDevic
 	deviceOwner := user.Subject
 
 	if req.Owner != nil {
-		if user.Claims.Has("admin", "true") {
+		if user.Claims.IsAdmin() {
 			deviceOwner = req.Owner.Value
 		} else {
 			return nil, status.Errorf(codes.PermissionDenied, "must be an admin")
@@ -80,7 +80,7 @@ func (d *DeviceService) ListAllDevices(ctx context.Context, req *proto.ListAllDe
 		return nil, status.Errorf(codes.PermissionDenied, "not authenticated")
 	}
 
-	if !user.Claims.Has("admin", "true") {
+	if !user.Claims.IsAdmin() {
 		return nil, status.Errorf(codes.PermissionDenied, "must be an admin")
 	}
 

--- a/internal/services/server_service.go
+++ b/internal/services/server_service.go
@@ -65,7 +65,7 @@ func (s *ServerService) Info(ctx context.Context, req *proto.InfoReq) (*proto.In
 		MetadataEnabled:  !s.Config.DisableMetadata,
 		InactiveEnabled:  !s.Config.DisableInactive,
 		InactiveDuration: DurationToDurationpb(&s.Config.InactiveDuration),
-		IsAdmin:          user.Claims.Has("admin", "true"),
+		IsAdmin:          user.Claims.IsAdmin(),
 		AllowedIps:       allowedIPs(s.Config),
 		DnsEnabled:       s.Config.DNS.Enabled,
 		DnsAddress:       dnsAddress,

--- a/pkg/authnz/authconfig/basic.go
+++ b/pkg/authnz/authconfig/basic.go
@@ -5,11 +5,13 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/tg123/go-htpasswd"
+
 	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authruntime"
 	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authsession"
-
-	"github.com/tg123/go-htpasswd"
 )
+
+const BasicAuthProvider = "basic"
 
 type BasicAuthConfig struct {
 	// Users is a list of htpasswd encoded username:password pairs
@@ -21,7 +23,7 @@ type BasicAuthConfig struct {
 
 func (c *BasicAuthConfig) Provider() *authruntime.Provider {
 	return &authruntime.Provider{
-		Type: "Basic",
+		Type: BasicAuthProvider,
 		Invoke: func(w http.ResponseWriter, r *http.Request, runtime *authruntime.ProviderRuntime) {
 			basicAuthLogin(c, runtime)(w, r)
 		},
@@ -35,7 +37,7 @@ func basicAuthLogin(c *BasicAuthConfig, runtime *authruntime.ProviderRuntime) ht
 			if ok := checkCreds(c.Users, u, p); ok {
 				err := runtime.SetSession(w, r, &authsession.AuthSession{
 					Identity: &authsession.Identity{
-						Provider: "Basic",
+						Provider: BasicAuthProvider,
 						Subject:  u,
 						Name:     u,
 						Email:    "", // basic auth has no email

--- a/pkg/authnz/authconfig/gitlab.go
+++ b/pkg/authnz/authconfig/gitlab.go
@@ -2,6 +2,8 @@ package authconfig
 
 import "github.com/freifunkMUC/wg-access-server/pkg/authnz/authruntime"
 
+const GitlabAuthProvider = "gitlab"
+
 type GitlabConfig struct {
 	Name         string   `yaml:"name"`
 	BaseURL      string   `yaml:"baseURL"`
@@ -22,6 +24,6 @@ func (c *GitlabConfig) Provider() *authruntime.Provider {
 		EmailDomains: c.EmailDomains,
 	}
 	p := o.Provider()
-	p.Type = "Gitlab"
+	p.Type = GitlabAuthProvider
 	return p
 }

--- a/pkg/authnz/authconfig/oidc.go
+++ b/pkg/authnz/authconfig/oidc.go
@@ -7,10 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authruntime"
-	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authsession"
-	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authutil"
-
 	"github.com/coreos/go-oidc"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -18,7 +14,13 @@ import (
 	"golang.org/x/oauth2"
 	"gopkg.in/Knetic/govaluate.v2"
 	"gopkg.in/yaml.v2"
+
+	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authruntime"
+	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authsession"
+	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authutil"
 )
+
+const OIDCAuthProvider = "oidc"
 
 // OIDCConfig implements an OIDC client using the [Authorization Code Flow]
 // [Authorization Code Flow]: https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth
@@ -62,7 +64,7 @@ func (c *OIDCConfig) Provider() *authruntime.Provider {
 	}
 
 	return &authruntime.Provider{
-		Type: "OIDC",
+		Type: OIDCAuthProvider,
 		Invoke: func(w http.ResponseWriter, r *http.Request, runtime *authruntime.ProviderRuntime) {
 			c.loginHandler(runtime, oauthConfig)(w, r)
 		},

--- a/pkg/authnz/authconfig/simple.go
+++ b/pkg/authnz/authconfig/simple.go
@@ -12,6 +12,8 @@ import (
 	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authtemplates"
 )
 
+const SimpleAuthProvider = "simple"
+
 // SimpleAuthConfig is an alternative to BasicAuthConfig where the login happens through a login page and a POST request.
 type SimpleAuthConfig struct {
 	// Users is a list of htpasswd encoded username:password pairs
@@ -25,7 +27,7 @@ const postURL = "/signin/simpleauth"
 
 func (c *SimpleAuthConfig) Provider() *authruntime.Provider {
 	return &authruntime.Provider{
-		Type: "Simple",
+		Type: SimpleAuthProvider,
 		// The flow is as follows: /signin page -> navigation to /signin/{index}
 		// -> Invoke / simpleAuthLogin() renders login form -> POST to postURL / simpleAuthPostEndpoint()
 		// -> redirect to /
@@ -67,7 +69,7 @@ func simpleAuthPostEndpoint(c *SimpleAuthConfig, runtime *authruntime.ProviderRu
 		if u != "" && p != "" && checkCreds(c.Users, u, p) {
 			err = runtime.SetSession(w, r, &authsession.AuthSession{
 				Identity: &authsession.Identity{
-					Provider: "Simple",
+					Provider: SimpleAuthProvider,
 					Subject:  u,
 					Name:     u,
 					Email:    "", // simple auth has no email

--- a/pkg/authnz/authsession/claims.go
+++ b/pkg/authnz/authsession/claims.go
@@ -1,5 +1,7 @@
 package authsession
 
+const adminClaim = "admin"
+
 type claim struct {
 	Name  string
 	Value string
@@ -32,4 +34,15 @@ func (c *Claims) Has(claim string, value string) bool {
 		}
 	}
 	return false
+}
+
+func (c *Claims) IsAdmin() bool {
+	return c.Has(adminClaim, "true")
+}
+
+func (c *Claims) MakeAdmin() {
+	if c == nil {
+		return
+	}
+	c.Add(adminClaim, "true")
 }

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-bullseye as proto-js
+FROM node:19-bullseye as proto-js
 RUN apt-get update && apt-get install -y protobuf-compiler libprotobuf-dev
 WORKDIR /code
 COPY ./website/package.json ./


### PR DESCRIPTION
Hi,

This is a PR in a serie of 6 PRs, as it was asked to split https://github.com/freifunkMUC/wg-access-server/pull/294 up into multiple PRs.

**Serie:**

* feature/bring-your-own-public-key
* feature/remove-all-devices-for-user
* feature/purge-inactive-devices
* feature/health-check
* **(THIS PR)** hygiene/put-common-auth-logic-into-func
* feature/pre-shared-keys 

**Code Hygiene:**

There are no new features but some cleanups:
* hardcoded checks are outsourced in a function
* login related code is moved to the authnz package
* a failed login gives reasonable status codes
* the node version for building the proto stubs is updated

