### PR TITLE
Dependabot: Request review from wg-access team

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,23 +6,23 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule: {interval: monthly}
-    reviewers: [freifunkMUC/salt-stack]
-    assignees: [freifunkMUC/salt-stack]
+    reviewers: [freifunkMUC/wg-access]
+    assignees: [freifunkMUC/wg-access]
 
   - package-ecosystem: github-actions
     directory: /
     schedule: {interval: monthly}
-    reviewers: [freifunkMUC/salt-stack]
-    assignees: [freifunkMUC/salt-stack]
+    reviewers: [freifunkMUC/wg-access]
+    assignees: [freifunkMUC/wg-access]
 
   - package-ecosystem: docker
     directory: /
     schedule: {interval: monthly}
-    reviewers: [freifunkMUC/salt-stack]
-    assignees: [freifunkMUC/salt-stack]
+    reviewers: [freifunkMUC/wg-access]
+    assignees: [freifunkMUC/wg-access]
 
   - package-ecosystem: npm
     directory: /website
     schedule: {interval: monthly}
-    reviewers: [freifunkMUC/salt-stack]
-    assignees: [freifunkMUC/salt-stack]
+    reviewers: [freifunkMUC/wg-access]
+    assignees: [freifunkMUC/wg-access]


### PR DESCRIPTION
## Problem
All the recent Dependabot PRs had the following error message:

> Dependabot tried to add `@freifunkMUC/salt-stack` as a reviewer to this PR, but received the following error from GitHub:
> 
> ```
> POST https://api.github.com/repos/freifunkMUC/wg-access-server/pulls/332/requested_reviewers: 422 - Reviews may only be requested from collaborators. One or more of the teams you specified is not a collaborator of the freifunkMUC/wg-access-server repository. // See: https://docs.github.com/rest/reference/pulls#request-reviewers-for-a-pull-request
> ```

https://github.com/freifunkMUC/wg-access-server/pull/332#issuecomment-1450767151

I believe the review requests never worked, but now Dependabot explicitly shows that it encountered this error.

## Changes
We have the freifunkMUC/wg-access team nowadasy, which has "Matinain" permissions for this repository, which should also count as "collaborator".
The `dependabot.yml` is now changed to request reviews from and assign the PRs to this wg-access team.