### PR TITLE
Moves 'Devices' section on admin page to the top to prevent scrolling.

### DIFF
--- a/website/src/pages/admin/AllDevices.tsx
+++ b/website/src/pages/admin/AllDevices.tsx
@@ -67,33 +67,7 @@ export const AllDevices = observer(class AllDevices extends React.Component {
 
     return (
       <div style={{ display: 'grid', gridGap: 25, gridAutoFlow: 'row' }}>
-        <Typography variant="h5" component="h5">
-          Users
-        </Typography>
-        <TableContainer>
-          <Table stickyHeader>
-            <TableHead>
-              <TableRow>
-                <TableCell>Name</TableCell>
-                <TableCell>Actions</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {users.map((user, i) => (
-                <TableRow key={i}>
-                  <TableCell component="th" scope="row">
-                    {user.displayName || user.name}
-                  </TableCell>
-                  <TableCell>
-                    <Button variant="outlined" color="secondary" onClick={() => this.deleteUser(user)}>
-                      Delete
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
+
         <Typography variant="h5" component="h5">
           Devices
         </Typography>
@@ -142,6 +116,35 @@ export const AllDevices = observer(class AllDevices extends React.Component {
             </TableBody>
           </Table>
         </TableContainer>
+
+        <Typography variant="h5" component="h5">
+            Users
+        </Typography>
+        <TableContainer>
+            <Table stickyHeader>
+                <TableHead>
+                    <TableRow>
+                        <TableCell>Name</TableCell>
+                        <TableCell>Actions</TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {users.map((user, i) => (
+                        <TableRow key={i}>
+                            <TableCell component="th" scope="row">
+                                {user.displayName || user.name}
+                            </TableCell>
+                            <TableCell>
+                                <Button variant="outlined" color="secondary" onClick={() => this.deleteUser(user)}>
+                                    Delete
+                                </Button>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </TableContainer>
+
         <Typography variant="h5" component="h5">
           Server Info
         </Typography>
@@ -151,6 +154,7 @@ export const AllDevices = observer(class AllDevices extends React.Component {
 
           </pre>
         </code>
+
       </div>
     );
   }


### PR DESCRIPTION
The devices section is the more interesting part of this admin page for day-to-day business and if there are more than half a dozend users one has to scroll on every visit.

Before:
![2023-05-15_08-21](https://github.com/freifunkMUC/wg-access-server/assets/3245637/c0ffa708-b595-46cf-bf34-6b47b0485c50)

After:
![2023-05-15_08-22](https://github.com/freifunkMUC/wg-access-server/assets/3245637/8fad16eb-9c03-4315-b7cf-6b3b8a4ace63)
