### PR TITLE
Adds IntelliJ IDEA project files to `.gitignore` and `.dockerignore`.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 .git/
 .github/
 .vscode/
+.idea/*
+*.iml
 docs/
 Dockerfile
 proto/Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+.idea/*
+*.iml
 
 ### Go ###
 # Binaries for programs and plugins


### PR DESCRIPTION
This keeps the workspace clean for IntelliJ users.