### PR TITLE
Adds the auth methods 'name' field to the login buttons, if it differs from the auth type.

### DIFF
--- a/docs/4-auth.md
+++ b/docs/4-auth.md
@@ -56,7 +56,7 @@ auth:
     # You can create a user using "htpasswd -nB <username>"
     users: []
   oidc:
-    # A name for the backend (can be anything you want)
+    # A name for the backend (is shown on the login page and possibly in the devices list of the 'all devices' admin page)
     name: "My OIDC Backend"
     # Should point to the OIDC Issuer (excluding /.well-known/openid-configuration)
     issuer: "https://identity.example.com"

--- a/pkg/authnz/authconfig/authconfig.go
+++ b/pkg/authnz/authconfig/authconfig.go
@@ -20,8 +20,8 @@ func (c *AuthConfig) IsEnabled() bool {
 	return c.OIDC != nil || c.Gitlab != nil || c.Basic != nil || c.Simple != nil
 }
 
-func (c *AuthConfig) DesiresSigninPage() bool {
-	// Basic auth is the only that truly needs the signin button
+func (c *AuthConfig) DesiresSignInPage() bool {
+	// Basic auth is the only that truly needs the sign-in button
 	return c.Basic != nil
 }
 

--- a/pkg/authnz/authconfig/basic.go
+++ b/pkg/authnz/authconfig/basic.go
@@ -24,6 +24,7 @@ type BasicAuthConfig struct {
 func (c *BasicAuthConfig) Provider() *authruntime.Provider {
 	return &authruntime.Provider{
 		Type: BasicAuthProvider,
+		Name: BasicAuthProvider,
 		Invoke: func(w http.ResponseWriter, r *http.Request, runtime *authruntime.ProviderRuntime) {
 			basicAuthLogin(c, runtime)(w, r)
 		},

--- a/pkg/authnz/authconfig/gitlab.go
+++ b/pkg/authnz/authconfig/gitlab.go
@@ -1,6 +1,8 @@
 package authconfig
 
-import "github.com/freifunkMUC/wg-access-server/pkg/authnz/authruntime"
+import (
+	"github.com/freifunkMUC/wg-access-server/pkg/authnz/authruntime"
+)
 
 const GitlabAuthProvider = "gitlab"
 
@@ -14,7 +16,7 @@ type GitlabConfig struct {
 }
 
 func (c *GitlabConfig) Provider() *authruntime.Provider {
-	o := OIDCConfig{
+	o := OIDCConfig {
 		Name:         c.Name,
 		Issuer:       c.BaseURL,
 		ClientID:     c.ClientID,
@@ -25,5 +27,6 @@ func (c *GitlabConfig) Provider() *authruntime.Provider {
 	}
 	p := o.Provider()
 	p.Type = GitlabAuthProvider
+	p.Name = c.Name
 	return p
 }

--- a/pkg/authnz/authconfig/oidc.go
+++ b/pkg/authnz/authconfig/oidc.go
@@ -65,6 +65,7 @@ func (c *OIDCConfig) Provider() *authruntime.Provider {
 
 	return &authruntime.Provider{
 		Type: OIDCAuthProvider,
+		Name: c.Name,
 		Invoke: func(w http.ResponseWriter, r *http.Request, runtime *authruntime.ProviderRuntime) {
 			c.loginHandler(runtime, oauthConfig)(w, r)
 		},

--- a/pkg/authnz/authconfig/simple.go
+++ b/pkg/authnz/authconfig/simple.go
@@ -28,6 +28,7 @@ const postURL = "/signin/simpleauth"
 func (c *SimpleAuthConfig) Provider() *authruntime.Provider {
 	return &authruntime.Provider{
 		Type: SimpleAuthProvider,
+		Name: SimpleAuthProvider,
 		// The flow is as follows: /signin page -> navigation to /signin/{index}
 		// -> Invoke / simpleAuthLogin() renders login form -> POST to postURL / simpleAuthPostEndpoint()
 		// -> redirect to /

--- a/pkg/authnz/authruntime/runtime.go
+++ b/pkg/authnz/authruntime/runtime.go
@@ -11,6 +11,7 @@ import (
 
 type Provider struct {
 	Type           string
+	Name           string
 	Invoke         func(http.ResponseWriter, *http.Request, *ProviderRuntime)
 	RegisterRoutes func(*mux.Router, *ProviderRuntime) error
 }

--- a/pkg/authnz/authtemplates/login.go.html
+++ b/pkg/authnz/authtemplates/login.go.html
@@ -5,7 +5,11 @@
 
 	{{range $i, $p := .Providers}}
 	<a href="/signin/{{$i}}">
-		<button>{{$p.Type}}</button>
+		{{ if ne $p.Name $p.Type }}
+			<button>{{$p.Name}} ({{$p.Type}})</button>
+		{{ else }}
+			<button>{{$p.Type}}</button>
+		{{ end }}
 	</a>
 	{{end}}
 

--- a/pkg/authnz/router.go
+++ b/pkg/authnz/router.go
@@ -71,7 +71,7 @@ func New(config authconfig.AuthConfig, claimsMiddleware authsession.ClaimsMiddle
 	}
 
 	router.HandleFunc("/signin", func(w http.ResponseWriter, r *http.Request) {
-		if r.FormValue("signout") != "1" && !config.DesiresSigninPage() && len(providers) == 1 {
+		if r.FormValue("signout") != "1" && !config.DesiresSignInPage() && len(providers) == 1 {
 			// we only have one provider, so jump directly to that
 			providers[0].Invoke(w, r, runtime)
 			return


### PR DESCRIPTION
This is supposed to improve the usability for non-IT corporate users:
We had a hard time* to convince our technically less inclined users that 'OIDC' in fact means our companys Keycloak SSO server. I always wished I could arbitrarily name the login buttons; hence this feature.

What do you think?

(* actually not _really_ hard, but for the sake of the argument... :grimacing: )

---

Given this config file extract:
```
...
auth:
  ...
  oidc:
    # A name for the backend (is shown on the login page and possibly in the devices list of the 'all devices' admin page)
    name: "MyCompany SSO"
    ...

  gitlab:
    name: "MyCompany Gitlab"
    ...
```
the login screen previously looked like this:
![2023-05-15_20-46](https://github.com/freifunkMUC/wg-access-server/assets/3245637/9748f8e3-ab12-4490-bde8-092537af6835)

and with this change would look like this:
![2023-05-15_20-49](https://github.com/freifunkMUC/wg-access-server/assets/3245637/25fa9e1a-c68e-41a7-8d6e-9c5b8721bf97)

To implicitly reproduce the old behavior one would need to set the name to the type:
```
  gitlab:
    name: "gitlab"

```

