### PR TITLE
Update pymdown-extenstions to non-vuln version

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,4 +2,4 @@ markdown-include~=0.6.0
 mkdocs~=1.3.0
 mkdocs-material~=8.3.8
 pygments~=2.12.0
-pymdown-extensions~=9.5
+pymdown-extensions>=10.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,4 +2,4 @@ markdown-include~=0.6.0
 mkdocs~=1.3.0
 mkdocs-material~=8.3.8
 pygments~=2.12.0
-pymdown-extensions>=10.0
+pymdown-extensions~=10.*


### PR DESCRIPTION
### Summary
This PR updates the pymdown-extensions to a non-vulnerable version.
Arbitrary file read when using include file syntax.
### Details

By using the syntax --8<--"/etc/passwd" or --8<--"/proc/self/environ" the content of these files will be rendered in the generated documentation. Additionally, a path relative to a specified, allowed base path can also be used to render the content of a file outside the specified base paths: --8<-- "../../../../etc/passwd".

Within the Snippets extension, there exists a base_path option but the implementation is vulnerable to Directory Traversal.
The vulnerable section exists in get_snippet_path(self, path) lines 155 to 174 in snippets.py.
```
base = "docs"
path = "/etc/passwd"
filename = os.path.join(base,path) # Filename is now /etc/passwd
```
### PoC
```
import markdown

payload = "--8<-- \"/etc/passwd\""
html = markdown.markdown(payload, extensions=['pymdownx.snippets'])

print(html)
```
### Impact

Any readable file on the host where the plugin is executing may have its content exposed. This can impact any use of Snippets that exposes the use of Snippets to external users.

It is never recommended to use Snippets to process user-facing, dynamic content. It is designed to process known content on the backend under the control of the host, but if someone were to accidentally enable it for user-facing content, undesired information could be exposed.