### PR TITLE
Change welcome title to project name

### DIFF
--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -9,6 +9,7 @@ import Typography from '@material-ui/core/Typography';
 import Link from '@material-ui/core/Link';
 import Button from '@material-ui/core/Button';
 import Chip from '@material-ui/core/Chip';
+import VpnKey from "@material-ui/icons/VpnKey";
 
 const useStyles = makeStyles((theme) => ({
   title: {
@@ -24,7 +25,7 @@ export default function Navigation() {
       <Toolbar>
         <Typography variant="h6" className={classes.title}>
           <Link to="/" color="inherit" component={NavLink}>
-            Welcome
+            <VpnKey /> wg-access-server
           </Link>
           {AppState.info?.isAdmin && (
             <Chip

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -45,7 +45,8 @@ td.MuiTableCell-root, th.MuiTableCell-root {
     font-size: 100%;
 }
 
-.MuiFormHelperText-root.Mui-error svg {
+/* Properly places icons in front of text, e.g. in the title line, or the add device error message. */
+.MuiFormHelperText-root.Mui-error svg, h6.MuiTypography-root svg {
   position: relative;
   top: 0.25em;
   margin-right: 8px;


### PR DESCRIPTION
Proposal for the change of this very generic 'Welcome' banner in the navigation bar to the project name 'wg-access-server'.

Before:
![2023-07-01_18-49](https://github.com/freifunkMUC/wg-access-server/assets/3245637/678bef0e-a69f-43f7-8ea3-48d02e09d17a)

After:
![2023-07-01_18-47](https://github.com/freifunkMUC/wg-access-server/assets/3245637/7431c1de-6ae4-426f-86e3-13abe7278599)

What do you think?