### PR TITLE
Improves logging

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,2 +1,2 @@
 [files]
-extend-exclude = ["go.sum", "package-lock.json"]
+extend-exclude = ["go.sum", "package-lock.json", "go.mod"]

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -119,7 +119,7 @@ func (cmd *servecmd) Run() {
 		}
 		wgimpl, err := wgembed.NewWithOpts(wgOpts)
 		if err != nil {
-			logrus.Fatal(errors.Wrap(err, "Failed to create WireGuard interface"))
+			logrus.Fatal(errors.Wrap(err, "failed to create WireGuard interface"))
 		}
 		defer wgimpl.Close()
 		wg = wgimpl
@@ -135,7 +135,7 @@ func (cmd *servecmd) Run() {
 		}
 
 		if err := wg.LoadConfig(wgconfig); err != nil {
-			logrus.Error(errors.Wrap(err, "Failed to load WireGuard config"))
+			logrus.Error(errors.Wrap(err, "failed to load WireGuard config"))
 			return
 		}
 
@@ -160,11 +160,11 @@ func (cmd *servecmd) Run() {
 	// Storage
 	storageBackend, err := storage.NewStorage(conf.Storage)
 	if err != nil {
-		logrus.Error(errors.Wrap(err, "Failed to create storage backend"))
+		logrus.Error(errors.Wrap(err, "failed to create storage backend"))
 		return
 	}
 	if err := storageBackend.Open(); err != nil {
-		logrus.Error(errors.Wrap(err, "Failed to connect/open storage backend"))
+		logrus.Error(errors.Wrap(err, "failed to connect/open storage backend"))
 		return
 	}
 	defer storageBackend.Close()
@@ -187,7 +187,7 @@ func (cmd *servecmd) Run() {
 			ListenAddr: listenAddr,
 		})
 		if err != nil {
-			logrus.Error(errors.Wrap(err, "Failed to create dns server"))
+			logrus.Error(errors.Wrap(err, "failed to create dns server"))
 			return
 		}
 		dns.ListenAndServe()
@@ -214,7 +214,7 @@ func (cmd *servecmd) Run() {
 
 	// Services
 	if err := deviceManager.StartSync(conf.DisableMetadata, conf.EnableInactiveDeviceDeletion, conf.InactiveDeviceGracePeriod); err != nil {
-		logrus.Error(errors.Wrap(err, "Failed to sync"))
+		logrus.Error(errors.Wrap(err, "failed to sync"))
 		return
 	}
 
@@ -228,7 +228,7 @@ func (cmd *servecmd) Run() {
 	// Authentication middleware
 	middleware, err := authnz.NewMiddleware(conf.Auth, authnz.ClaimsMiddleware(conf))
 	if err != nil {
-		logrus.Error(errors.Wrap(err, "Failed to set up authnz middleware"))
+		logrus.Error(errors.Wrap(err, "failed to set up authnz middleware"))
 		return
 	}
 	router.Use(middleware)
@@ -265,7 +265,7 @@ func (cmd *servecmd) Run() {
 		logrus.Infof("Web UI listening on %v", address)
 		err := srv.ListenAndServe()
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errChan <- errors.Wrap(err, "Unable to start http server")
+			errChan <- errors.Wrap(err, "unable to start http server")
 		}
 	}()
 
@@ -289,7 +289,7 @@ func (cmd *servecmd) ReadConfig() *config.AppConfig {
 	if cmd.ConfigFilePath != "" {
 		if b, err := ioutil.ReadFile(cmd.ConfigFilePath); err == nil {
 			if err := yaml.Unmarshal(b, &cmd.AppConfig); err != nil {
-				logrus.Fatal(errors.Wrap(err, "Failed to bind configuration file"))
+				logrus.Fatal(errors.Wrap(err, "failed to bind configuration file"))
 			}
 		}
 	}
@@ -314,7 +314,7 @@ func (cmd *servecmd) ReadConfig() *config.AppConfig {
 		// set a basic auth entry for the admin user
 		pw, err := bcrypt.GenerateFromPassword([]byte(cmd.AppConfig.AdminPassword), bcrypt.DefaultCost)
 		if err != nil {
-			logrus.Fatal(errors.Wrap(err, "Failed to generate a bcrypt hash for the provided admin password"))
+			logrus.Fatal(errors.Wrap(err, "failed to generate a bcrypt hash for the provided admin password"))
 		}
 		if cmd.AppConfig.Auth.Simple == nil && cmd.AppConfig.Auth.Basic == nil {
 			// basic and simple auth are unset, enable simple auth for the admin user
@@ -337,7 +337,7 @@ func (cmd *servecmd) ReadConfig() *config.AppConfig {
 		}
 		key, err := wgtypes.GeneratePrivateKey()
 		if err != nil {
-			logrus.Fatal(errors.Wrap(err, "Failed to generate a server private key"))
+			logrus.Fatal(errors.Wrap(err, "failed to generate a server private key"))
 		}
 		cmd.AppConfig.WireGuard.PrivateKey = key.String()
 	}
@@ -396,7 +396,7 @@ func detectDNSUpstream(ipv4Enabled, ipv6Enabled bool) []string {
 func detectDefaultInterface() string {
 	links, err := netlink.LinkList()
 	if err != nil {
-		logrus.Warn(errors.Wrap(err, "Failed to list network interfaces"))
+		logrus.Warn(errors.Wrap(err, "failed to list network interfaces"))
 		return ""
 	}
 	for _, link := range links {
@@ -404,7 +404,7 @@ func detectDefaultInterface() string {
 		for family := range []int{4, 6} {
 			routes, err := netlink.RouteList(link, family)
 			if err != nil {
-				logrus.Warn(errors.Wrapf(err, "Failed to list routes for interface %s", link.Attrs().Name))
+				logrus.Warn(errors.Wrapf(err, "failed to list routes for interface %s", link.Attrs().Name))
 				return ""
 			}
 			for _, route := range routes {
@@ -421,7 +421,7 @@ func detectDefaultInterface() string {
 func generateZone(deviceManager *devices.DeviceManager, vpnips []netip.Addr) dnsproxy.Zone {
 	devs, err := deviceManager.ListAllDevices()
 	if err != nil {
-		logrus.Error(errors.Wrap(err, "Could not query devices to generate the DNS zone"))
+		logrus.Error(errors.Wrap(err, "could not query devices to generate the DNS zone"))
 	}
 
 	zone := make(dnsproxy.Zone)

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -87,7 +87,7 @@ func (cmd *servecmd) Run() {
 		logrus.Fatal(err)
 	}
 	if !vpnip.IsValid() && !vpnipv6.IsValid() {
-		logrus.Fatal("need at least one of VPN.CIDR or VPN.CIDRv6 set")
+		logrus.Fatal("Need at least one of VPN.CIDR or VPN.CIDRv6 set")
 	}
 
 	// Allow traffic to wg-access-server's peer endpoint.
@@ -119,12 +119,12 @@ func (cmd *servecmd) Run() {
 		}
 		wgimpl, err := wgembed.NewWithOpts(wgOpts)
 		if err != nil {
-			logrus.Fatal(errors.Wrap(err, "failed to create wireguard interface"))
+			logrus.Fatal(errors.Wrap(err, "Failed to create WireGuard interface"))
 		}
 		defer wgimpl.Close()
 		wg = wgimpl
 
-		logrus.Infof("starting wireguard server on :%d", conf.WireGuard.Port)
+		logrus.Infof("Starting WireGuard server on :%d", conf.WireGuard.Port)
 
 		wgconfig := &wgembed.ConfigFile{
 			Interface: wgembed.IfaceConfig{
@@ -135,11 +135,11 @@ func (cmd *servecmd) Run() {
 		}
 
 		if err := wg.LoadConfig(wgconfig); err != nil {
-			logrus.Error(errors.Wrap(err, "failed to load wireguard config"))
+			logrus.Error(errors.Wrap(err, "Failed to load WireGuard config"))
 			return
 		}
 
-		logrus.Infof("wireguard VPN network is %s", network.StringJoinIPNets(vpnip, vpnipv6))
+		logrus.Infof("WireGuard VPN network is %s", network.StringJoinIPNets(vpnip, vpnipv6))
 
 		options := network.ForwardingOptions{
 			GatewayIface:    conf.VPN.GatewayInterface,
@@ -160,11 +160,11 @@ func (cmd *servecmd) Run() {
 	// Storage
 	storageBackend, err := storage.NewStorage(conf.Storage)
 	if err != nil {
-		logrus.Error(errors.Wrap(err, "failed to create storage backend"))
+		logrus.Error(errors.Wrap(err, "Failed to create storage backend"))
 		return
 	}
 	if err := storageBackend.Open(); err != nil {
-		logrus.Error(errors.Wrap(err, "failed to connect/open storage backend"))
+		logrus.Error(errors.Wrap(err, "Failed to connect/open storage backend"))
 		return
 	}
 	defer storageBackend.Close()
@@ -187,7 +187,7 @@ func (cmd *servecmd) Run() {
 			ListenAddr: listenAddr,
 		})
 		if err != nil {
-			logrus.Error(errors.Wrap(err, "failed to create dns server"))
+			logrus.Error(errors.Wrap(err, "Failed to create dns server"))
 			return
 		}
 		dns.ListenAndServe()
@@ -214,7 +214,7 @@ func (cmd *servecmd) Run() {
 
 	// Services
 	if err := deviceManager.StartSync(conf.DisableMetadata, conf.EnableInactiveDeviceDeletion, conf.InactiveDeviceGracePeriod); err != nil {
-		logrus.Error(errors.Wrap(err, "failed to sync"))
+		logrus.Error(errors.Wrap(err, "Failed to sync"))
 		return
 	}
 
@@ -228,7 +228,7 @@ func (cmd *servecmd) Run() {
 	// Authentication middleware
 	middleware, err := authnz.NewMiddleware(conf.Auth, authnz.ClaimsMiddleware(conf))
 	if err != nil {
-		logrus.Error(errors.Wrap(err, "failed to set up authnz middleware"))
+		logrus.Error(errors.Wrap(err, "Failed to set up authnz middleware"))
 		return
 	}
 	router.Use(middleware)
@@ -262,10 +262,10 @@ func (cmd *servecmd) Run() {
 
 	go func() {
 		// Start Web server
-		logrus.Infof("web ui listening on %v", address)
+		logrus.Infof("Web UI listening on %v", address)
 		err := srv.ListenAndServe()
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errChan <- errors.Wrap(err, "unable to start http server")
+			errChan <- errors.Wrap(err, "Unable to start http server")
 		}
 	}()
 
@@ -289,7 +289,7 @@ func (cmd *servecmd) ReadConfig() *config.AppConfig {
 	if cmd.ConfigFilePath != "" {
 		if b, err := ioutil.ReadFile(cmd.ConfigFilePath); err == nil {
 			if err := yaml.Unmarshal(b, &cmd.AppConfig); err != nil {
-				logrus.Fatal(errors.Wrap(err, "failed to bind configuration file"))
+				logrus.Fatal(errors.Wrap(err, "Failed to bind configuration file"))
 			}
 		}
 	}
@@ -306,7 +306,7 @@ func (cmd *servecmd) ReadConfig() *config.AppConfig {
 
 	if !cmd.AppConfig.Auth.IsEnabled() {
 		if cmd.AppConfig.AdminPassword == "" {
-			logrus.Fatal("missing admin password: please set via environment variable, flag or config file")
+			logrus.Fatal("Missing admin password: please set via environment variable, flag or config file")
 		}
 	}
 
@@ -314,7 +314,7 @@ func (cmd *servecmd) ReadConfig() *config.AppConfig {
 		// set a basic auth entry for the admin user
 		pw, err := bcrypt.GenerateFromPassword([]byte(cmd.AppConfig.AdminPassword), bcrypt.DefaultCost)
 		if err != nil {
-			logrus.Fatal(errors.Wrap(err, "failed to generate a bcrypt hash for the provided admin password"))
+			logrus.Fatal(errors.Wrap(err, "Failed to generate a bcrypt hash for the provided admin password"))
 		}
 		if cmd.AppConfig.Auth.Simple == nil && cmd.AppConfig.Auth.Basic == nil {
 			// basic and simple auth are unset, enable simple auth for the admin user
@@ -337,7 +337,7 @@ func (cmd *servecmd) ReadConfig() *config.AppConfig {
 		}
 		key, err := wgtypes.GeneratePrivateKey()
 		if err != nil {
-			logrus.Fatal(errors.Wrap(err, "failed to generate a server private key"))
+			logrus.Fatal(errors.Wrap(err, "Failed to generate a server private key"))
 		}
 		cmd.AppConfig.WireGuard.PrivateKey = key.String()
 	}
@@ -381,7 +381,7 @@ func detectDNSUpstream(ipv4Enabled, ipv6Enabled bool) []string {
 		upstream = resolvconf.GetNameservers(r.Content, types.IP)
 	}
 	if len(upstream) == 0 {
-		logrus.Warn("failed to get nameservers from /etc/resolv.conf defaulting to Cloudflare DNS instead")
+		logrus.Warn("Failed to get nameservers from /etc/resolv.conf defaulting to Cloudflare DNS instead")
 		// If there's no default route for IPv6, lookup fails immediately without delay and we retry using IPv4
 		if ipv6Enabled {
 			upstream = append(upstream, "2606:4700:4700::1111")
@@ -396,7 +396,7 @@ func detectDNSUpstream(ipv4Enabled, ipv6Enabled bool) []string {
 func detectDefaultInterface() string {
 	links, err := netlink.LinkList()
 	if err != nil {
-		logrus.Warn(errors.Wrap(err, "failed to list network interfaces"))
+		logrus.Warn(errors.Wrap(err, "Failed to list network interfaces"))
 		return ""
 	}
 	for _, link := range links {
@@ -404,7 +404,7 @@ func detectDefaultInterface() string {
 		for family := range []int{4, 6} {
 			routes, err := netlink.RouteList(link, family)
 			if err != nil {
-				logrus.Warn(errors.Wrapf(err, "failed to list routes for interface %s", link.Attrs().Name))
+				logrus.Warn(errors.Wrapf(err, "Failed to list routes for interface %s", link.Attrs().Name))
 				return ""
 			}
 			for _, route := range routes {
@@ -414,14 +414,14 @@ func detectDefaultInterface() string {
 			}
 		}
 	}
-	logrus.Warn(errors.New("could not determine the default network interface name"))
+	logrus.Warn(errors.New("Could not determine the default network interface name"))
 	return ""
 }
 
 func generateZone(deviceManager *devices.DeviceManager, vpnips []netip.Addr) dnsproxy.Zone {
 	devs, err := deviceManager.ListAllDevices()
 	if err != nil {
-		logrus.Error(errors.Wrap(err, "could not query devices to generate the DNS zone"))
+		logrus.Error(errors.Wrap(err, "Could not query devices to generate the DNS zone"))
 	}
 
 	zone := make(dnsproxy.Zone)
@@ -443,7 +443,7 @@ func generateZone(deviceManager *devices.DeviceManager, vpnips []netip.Addr) dns
 	return zone
 }
 
-var missingPrivateKey = `missing wireguard private key:
+var missingPrivateKey = `Missing WireGuard private key:
 
     create a key:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,7 +24,7 @@ type AppConfig struct {
 	// Defaults to 8000
 	Port int `yaml:"port"`
 	// ExternalHost is the address that clients
-	// use to connect to the wireguard interface
+	// use to connect to the WireGuard interface
 	// By default, this will be empty and the web ui
 	// will use the current page's origin.
 	ExternalHost string `yaml:"externalHost"`
@@ -50,7 +50,7 @@ type AppConfig struct {
 	Filename string `yaml:"filename"`
 	// Configure WireGuard related settings
 	WireGuard struct {
-		// Set this to false to disable the embedded wireguard
+		// Set this to false to disable the embedded WireGuard
 		// server. This is useful for development environments
 		// on mac and windows where we don't currently support
 		// the OS's network stack.

--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -40,26 +40,26 @@ func (d *DeviceManager) StartSync(disableMetadataCollection, enableInactiveDevic
 	d.storage.OnAdd(func(device *storage.Device) {
 		logrus.Infof("Storage event: add device '%s' (public key: '%s') for user: %s %s", device.Name, device.PublicKey, device.OwnerName, device.Owner)
 		if err := d.wg.AddPeer(device.PublicKey, device.PresharedKey, network.SplitAddresses(device.Address)); err != nil {
-			logrus.Error(errors.Wrap(err, "Failed to add WireGuard peer"))
+			logrus.Error(errors.Wrap(err, "failed to add WireGuard peer"))
 		}
 	})
 
 	d.storage.OnDelete(func(device *storage.Device) {
 		logrus.Infof("Storage event: remove device '%s' (public key: '%s') for user: %s %s", device.Name, device.PublicKey, device.OwnerName, device.Owner)
 		if err := d.wg.RemovePeer(device.PublicKey); err != nil {
-			logrus.Error(errors.Wrap(err, "Failed to remove WireGuard peer"))
+			logrus.Error(errors.Wrap(err, "failed to remove WireGuard peer"))
 		}
 	})
 
 	d.storage.OnReconnect(func() {
 		if err := d.sync(); err != nil {
-			logrus.Error(errors.Wrap(err, "Device sync after storage backend reconnect event failed"))
+			logrus.Error(errors.Wrap(err, "device sync after storage backend reconnect event failed"))
 		}
 	})
 
 	// Do an initial sync of existing devices
 	if err := d.sync(); err != nil {
-		return errors.Wrap(err, "Initial device sync from storage failed")
+		return errors.Wrap(err, "initial device sync from storage failed")
 	}
 
 	// start the metrics loop
@@ -89,7 +89,7 @@ func (d *DeviceManager) AddDevice(identity *authsession.Identity, name string, p
 	var nameTaken bool = false
 	devices, err := d.ListDevices(identity.Subject)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to list devices")
+		return nil, errors.Wrap(err, "failed to list devices")
 	}
 
 	for _, x := range devices {
@@ -114,7 +114,7 @@ func (d *DeviceManager) AddDevice(identity *authsession.Identity, name string, p
 
 	clientAddr, err := d.nextClientAddress()
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to generate an ip address for device")
+		return nil, errors.Wrap(err, "failed to generate an ip address for device")
 	}
 
 	device := &storage.Device{
@@ -130,7 +130,7 @@ func (d *DeviceManager) AddDevice(identity *authsession.Identity, name string, p
 	}
 
 	if err := d.SaveDevice(device); err != nil {
-		return nil, errors.Wrap(err, "Failed to save the new device")
+		return nil, errors.Wrap(err, "failed to save the new device")
 	}
 
 	return device, nil
@@ -143,19 +143,19 @@ func (d *DeviceManager) SaveDevice(device *storage.Device) error {
 func (d *DeviceManager) sync() error {
 	devices, err := d.ListAllDevices()
 	if err != nil {
-		return errors.Wrap(err, "Failed to list devices")
+		return errors.Wrap(err, "failed to list devices")
 	}
 
 	peers, err := d.wg.ListPeers()
 	if err != nil {
-		return errors.Wrap(err, "Failed to list peers")
+		return errors.Wrap(err, "failed to list peers")
 	}
 
 	// Remove any peers for devices that are no longer in storage
 	for _, peer := range peers {
 		if !deviceListContains(devices, peer.PublicKey.String()) {
 			if err := d.wg.RemovePeer(peer.PublicKey.String()); err != nil {
-				logrus.Error(errors.Wrapf(err, "Failed to remove peer during sync: %s", peer.PublicKey.String()))
+				logrus.Error(errors.Wrapf(err, "failed to remove peer during sync: %s", peer.PublicKey.String()))
 			}
 		}
 	}
@@ -163,7 +163,7 @@ func (d *DeviceManager) sync() error {
 	// Add peers for all devices in storage
 	for _, device := range devices {
 		if err := d.wg.AddPeer(device.PublicKey, device.PresharedKey, network.SplitAddresses(device.Address)); err != nil {
-			logrus.Warn(errors.Wrapf(err, "Failed to add device during sync: %s", device.Name))
+			logrus.Warn(errors.Wrapf(err, "failed to add device during sync: %s", device.Name))
 		}
 	}
 
@@ -181,7 +181,7 @@ func (d *DeviceManager) ListDevices(user string) ([]*storage.Device, error) {
 func (d *DeviceManager) DeleteDevice(user string, name string) error {
 	device, err := d.storage.Get(user, name)
 	if err != nil {
-		return errors.Wrap(err, "Failed to retrieve device")
+		return errors.Wrap(err, "failed to retrieve device")
 	}
 
 	if err := d.storage.Delete(device); err != nil {
@@ -203,7 +203,7 @@ func (d *DeviceManager) nextClientAddress() (string, error) {
 
 	devices, err := d.ListDevices("")
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to list devices")
+		return "", errors.Wrap(err, "failed to list devices")
 	}
 
 	// TODO: read up on better ways to allocate client's IP
@@ -291,7 +291,7 @@ func deviceListContains(devices []*storage.Device, publicKey string) bool {
 func (d *DeviceManager) ListUsers() ([]*User, error) {
 	devices, err := d.storage.List("")
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to retrieve devices")
+		return nil, errors.Wrap(err, "failed to retrieve devices")
 	}
 
 	seen := map[string]bool{}
@@ -309,13 +309,13 @@ func (d *DeviceManager) ListUsers() ([]*User, error) {
 func (d *DeviceManager) DeleteDevicesForUser(user string) error {
 	devices, err := d.ListDevices(user)
 	if err != nil {
-		return errors.Wrap(err, "Failed to retrieve devices")
+		return errors.Wrap(err, "failed to retrieve devices")
 	}
 
 	for _, dev := range devices {
 		// TODO not transactional
 		if err := d.DeleteDevice(user, dev.Name); err != nil {
-			return errors.Wrap(err, "Failed to delete device")
+			return errors.Wrap(err, "failed to delete device")
 		}
 	}
 
@@ -324,11 +324,11 @@ func (d *DeviceManager) DeleteDevicesForUser(user string) error {
 
 func (d *DeviceManager) Ping() error {
 	if err := d.storage.Ping(); err != nil {
-		return errors.Wrap(err, "Failed to ping storage")
+		return errors.Wrap(err, "failed to ping storage")
 	}
 
 	if err := d.wg.Ping(); err != nil {
-		return errors.Wrap(err, "Failed to ping WireGuard")
+		return errors.Wrap(err, "failed to ping WireGuard")
 	}
 
 	return nil

--- a/internal/devices/inactive.go
+++ b/internal/devices/inactive.go
@@ -16,16 +16,16 @@ func inactiveLoop(d *DeviceManager, inactiveDeviceGracePeriod time.Duration) {
 }
 
 func checkAndRemove(d *DeviceManager, inactiveDeviceGracePeriod time.Duration) {
-	logrus.Debug("inactive check executing")
+	logrus.Debug("Inactive check executing")
 
 	devices, err := d.ListAllDevices()
 	if err != nil {
-		logrus.Warn(errors.Wrap(err, "failed to list devices - inactive devices cannot be deleted"))
+		logrus.Warn(errors.Wrap(err, "Failed to list devices - inactive devices cannot be deleted"))
 		return
 	}
 
 	for _, dev := range devices {
-		logrus.Debugf("checking inactive device: %s/%s", dev.Owner, dev.Name)
+		logrus.Debugf("Checking inactive device: %s/%s", dev.Owner, dev.Name)
 
 		var elapsed time.Duration
 		if dev.LastHandshakeTime == nil {
@@ -36,10 +36,10 @@ func checkAndRemove(d *DeviceManager, inactiveDeviceGracePeriod time.Duration) {
 		}
 
 		if elapsed > inactiveDeviceGracePeriod {
-			logrus.Warnf("deleting inactive device: %s/%s", dev.Owner, dev.Name)
+			logrus.Warnf("Deleting inactive device: %s/%s", dev.Owner, dev.Name)
 			err := d.DeleteDevice(dev.Owner, dev.Name)
 			if err != nil {
-				logrus.Error(errors.Wrap(err, fmt.Sprintf("failed to delete device: %s/%s", dev.Owner, dev.Name)))
+				logrus.Error(errors.Wrap(err, fmt.Sprintf("Failed to delete device: %s/%s", dev.Owner, dev.Name)))
 				continue
 			}
 		}

--- a/internal/devices/inactive.go
+++ b/internal/devices/inactive.go
@@ -20,7 +20,7 @@ func checkAndRemove(d *DeviceManager, inactiveDeviceGracePeriod time.Duration) {
 
 	devices, err := d.ListAllDevices()
 	if err != nil {
-		logrus.Warn(errors.Wrap(err, "Failed to list devices - inactive devices cannot be deleted"))
+		logrus.Warn(errors.Wrap(err, "failed to list devices - inactive devices cannot be deleted"))
 		return
 	}
 
@@ -39,7 +39,7 @@ func checkAndRemove(d *DeviceManager, inactiveDeviceGracePeriod time.Duration) {
 			logrus.Warnf("Deleting inactive device: %s/%s", dev.Owner, dev.Name)
 			err := d.DeleteDevice(dev.Owner, dev.Name)
 			if err != nil {
-				logrus.Error(errors.Wrap(err, fmt.Sprintf("Failed to delete device: %s/%s", dev.Owner, dev.Name)))
+				logrus.Error(errors.Wrap(err, fmt.Sprintf("failed to delete device: %s/%s", dev.Owner, dev.Name)))
 				continue
 			}
 		}

--- a/internal/devices/metadata.go
+++ b/internal/devices/metadata.go
@@ -19,7 +19,7 @@ func syncMetrics(d *DeviceManager) {
 
 	peers, err := d.wg.ListPeers()
 	if err != nil {
-		logrus.Warn(errors.Wrap(err, "Failed to list peers - metrics cannot be recorded"))
+		logrus.Warn(errors.Wrap(err, "failed to list peers - metrics cannot be recorded"))
 		return
 	}
 
@@ -40,7 +40,7 @@ func syncMetrics(d *DeviceManager) {
 				device.LastHandshakeTime = &peer.LastHandshakeTime
 
 				if err := d.SaveDevice(device); err != nil {
-					logrus.Error(errors.Wrap(err, "Failed to save device during metadata sync"))
+					logrus.Error(errors.Wrap(err, "failed to save device during metadata sync"))
 				}
 			}
 		}

--- a/internal/devices/metadata.go
+++ b/internal/devices/metadata.go
@@ -15,11 +15,11 @@ func metadataLoop(d *DeviceManager) {
 }
 
 func syncMetrics(d *DeviceManager) {
-	logrus.Debug("metadata sync executing")
+	logrus.Debug("Metadata sync executing")
 
 	peers, err := d.wg.ListPeers()
 	if err != nil {
-		logrus.Warn(errors.Wrap(err, "failed to list peers - metrics cannot be recorded"))
+		logrus.Warn(errors.Wrap(err, "Failed to list peers - metrics cannot be recorded"))
 		return
 	}
 
@@ -40,7 +40,7 @@ func syncMetrics(d *DeviceManager) {
 				device.LastHandshakeTime = &peer.LastHandshakeTime
 
 				if err := d.SaveDevice(device); err != nil {
-					logrus.Error(errors.Wrap(err, "failed to save device during metadata sync"))
+					logrus.Error(errors.Wrap(err, "Failed to save device during metadata sync"))
 				}
 			}
 		}

--- a/internal/dnsproxy/server.go
+++ b/internal/dnsproxy/server.go
@@ -28,7 +28,7 @@ type DNSServer struct {
 // The returned server needs to be started using DNSServer.ListenAndServe()
 func New(opts DNSServerOpts) (*DNSServer, error) {
 	if len(opts.Upstream) == 0 {
-		return nil, errors.New("at least 1 upstream dns server is required for the dns proxy server to function")
+		return nil, errors.New("At least 1 upstream dns server is required for the dns proxy server to function")
 	}
 
 	dnsServer := &DNSServer{
@@ -92,7 +92,7 @@ func (d *DNSServer) ListenAndServe() {
 		}
 	}
 
-	logrus.Infof("starting dns server on %s with upstreams: %s", sb.String(), strings.Join(d.proxy.upstream, ", "))
+	logrus.Infof("Starting DNS server on %s with upstreams: %s", sb.String(), strings.Join(d.proxy.upstream, ", "))
 
 	var wg sync.WaitGroup
 
@@ -103,7 +103,7 @@ func (d *DNSServer) ListenAndServe() {
 		}
 		go func(server *dns.Server) {
 			if err := server.ListenAndServe(); err != nil {
-				logrus.Error(errors.Errorf("failed to start DNS server on %s/%s: %s", server.Addr, server.Net, err))
+				logrus.Error(errors.Errorf("Dailed to start DNS server on %s/%s: %s", server.Addr, server.Net, err))
 				wg.Done()
 			}
 		}(server)
@@ -158,7 +158,7 @@ func makekey(m *dns.Msg) string {
 
 func prettyPrintMsg(m *dns.Msg) string {
 	if len(m.Question) > 0 {
-		return fmt.Sprintf("dns query for: %s", makekey(m))
+		return fmt.Sprintf("DNS query for: %s", makekey(m))
 	}
 	return m.String()
 }

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -79,7 +79,7 @@ type ForwardingOptions struct {
 
 func ConfigureForwarding(options ForwardingOptions) error {
 	// Networking configuration (iptables) configuration
-	// to ensure that traffic from clients of the wireguard interface
+	// to ensure that traffic from clients of the WireGuard interface
 	// is sent to the provided network interface
 	allowedIPv4s := make([]string, 0, len(options.AllowedIPs)/2)
 	allowedIPv6s := make([]string, 0, len(options.AllowedIPs)/2)

--- a/internal/services/device_service.go
+++ b/internal/services/device_service.go
@@ -22,7 +22,7 @@ type DeviceService struct {
 func (d *DeviceService) AddDevice(ctx context.Context, req *proto.AddDeviceReq) (*proto.Device, error) {
 	user, err := authsession.CurrentUser(ctx)
 	if err != nil {
-		return nil, status.Errorf(codes.PermissionDenied, "not authenticated")
+		return nil, status.Errorf(codes.PermissionDenied, "Not authenticated")
 	}
 
 	device, err := d.DeviceManager.AddDevice(user, req.GetName(), req.GetPublicKey(), req.GetPresharedKey())
@@ -37,13 +37,13 @@ func (d *DeviceService) AddDevice(ctx context.Context, req *proto.AddDeviceReq) 
 func (d *DeviceService) ListDevices(ctx context.Context, req *proto.ListDevicesReq) (*proto.ListDevicesRes, error) {
 	user, err := authsession.CurrentUser(ctx)
 	if err != nil {
-		return nil, status.Errorf(codes.PermissionDenied, "not authenticated")
+		return nil, status.Errorf(codes.PermissionDenied, "Not authenticated")
 	}
 
 	devices, err := d.DeviceManager.ListDevices(user.Subject)
 	if err != nil {
 		ctxlogrus.Extract(ctx).Error(err)
-		return nil, status.Errorf(codes.Internal, "failed to retrieve devices")
+		return nil, status.Errorf(codes.Internal, "Failed to retrieve devices")
 	}
 	return &proto.ListDevicesRes{
 		Items: mapDevices(devices),
@@ -53,7 +53,7 @@ func (d *DeviceService) ListDevices(ctx context.Context, req *proto.ListDevicesR
 func (d *DeviceService) DeleteDevice(ctx context.Context, req *proto.DeleteDeviceReq) (*emptypb.Empty, error) {
 	user, err := authsession.CurrentUser(ctx)
 	if err != nil {
-		return nil, status.Errorf(codes.PermissionDenied, "not authenticated")
+		return nil, status.Errorf(codes.PermissionDenied, "Not authenticated")
 	}
 
 	deviceOwner := user.Subject
@@ -77,17 +77,17 @@ func (d *DeviceService) DeleteDevice(ctx context.Context, req *proto.DeleteDevic
 func (d *DeviceService) ListAllDevices(ctx context.Context, req *proto.ListAllDevicesReq) (*proto.ListAllDevicesRes, error) {
 	user, err := authsession.CurrentUser(ctx)
 	if err != nil {
-		return nil, status.Errorf(codes.PermissionDenied, "not authenticated")
+		return nil, status.Errorf(codes.PermissionDenied, "Not authenticated")
 	}
 
 	if !user.Claims.IsAdmin() {
-		return nil, status.Errorf(codes.PermissionDenied, "must be an admin")
+		return nil, status.Errorf(codes.PermissionDenied, "Must be an admin")
 	}
 
 	devices, err := d.DeviceManager.ListAllDevices()
 	if err != nil {
 		ctxlogrus.Extract(ctx).Error(err)
-		return nil, status.Errorf(codes.Internal, "failed to retrieve devices")
+		return nil, status.Errorf(codes.Internal, "Failed to retrieve devices")
 	}
 
 	return &proto.ListAllDevicesRes{
@@ -111,9 +111,9 @@ func mapDevice(d *storage.Device) *proto.Device {
 		TransmitBytes:     d.TransmitBytes,
 		Endpoint:          d.Endpoint,
 		/**
-		 * Wireguard is a connectionless UDP protocol - data is only
+		 * WireGuard is a connectionless UDP protocol - data is only
 		 * sent over the wire when the client is sending real traffic.
-		 * Wireguard has no keep alive packets by default to remain as
+		 * WireGuard has no keep alive packets by default to remain as
 		 * silent as possible.
 		 *
 		 */

--- a/internal/services/website_router.go
+++ b/internal/services/website_router.go
@@ -19,14 +19,14 @@ func WebsiteRouter() *mux.Router {
 
 	staticFiles, err := filepath.Abs("website/build")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "failed to create absolute path to website static files"))
+		logrus.Fatal(errors.Wrap(err, "Failed to create absolute path to website static files"))
 	}
 
 	if _, err := os.Stat(staticFiles); os.IsNotExist(err) {
 		// if the static files directory doesn't exist
 		// then proxy to a local webpack development server
 		// i.e. we're developing wg-access-server locally
-		logrus.Info("missing ./website/build - will reverse proxy to website dev server")
+		logrus.Info("Missing ./website/build - will reverse proxy to website dev server")
 		u, _ := url.Parse("http://localhost:3000")
 		router.NotFoundHandler = httputil.NewSingleHostReverseProxy(u)
 	} else {
@@ -34,7 +34,7 @@ func WebsiteRouter() *mux.Router {
 		// handle static file requests.
 		// the react app handles routing so we also
 		// add a catch-all route to serve the react index page.
-		logrus.Info("serving website from ./website/build")
+		logrus.Info("Serving website from ./website/build")
 		router.PathPrefix("/").Handler(
 			FileServerWith404(
 				http.Dir(staticFiles),

--- a/internal/services/website_router.go
+++ b/internal/services/website_router.go
@@ -19,7 +19,7 @@ func WebsiteRouter() *mux.Router {
 
 	staticFiles, err := filepath.Abs("website/build")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "Failed to create absolute path to website static files"))
+		logrus.Fatal(errors.Wrap(err, "failed to create absolute path to website static files"))
 	}
 
 	if _, err := os.Stat(staticFiles); os.IsNotExist(err) {

--- a/internal/storage/contracts.go
+++ b/internal/storage/contracts.go
@@ -62,12 +62,12 @@ type Device struct {
 func NewStorage(uri string) (Storage, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
-		return nil, errors.Wrap(err, "error parsing storage uri")
+		return nil, errors.Wrap(err, "Error parsing storage uri")
 	}
 
 	switch u.Scheme {
 	case "memory":
-		logrus.Warn("storing data in memory - devices will not persist between restarts")
+		logrus.Warn("Storing data in memory - devices will not persist between restarts")
 		return NewMemoryStorage(), nil
 	case "postgresql":
 		fallthrough
@@ -76,9 +76,9 @@ func NewStorage(uri string) (Storage, error) {
 	case "mysql":
 		fallthrough
 	case "sqlite3":
-		logrus.Infof("storing data in SQL backend %s", u.Scheme)
+		logrus.Infof("Storing data in SQL backend at %s", u)
 		return NewSqlStorage(u), nil
 	}
 
-	return nil, fmt.Errorf("unknown storage backend %s", u.Scheme)
+	return nil, fmt.Errorf("Unknown storage backend %s", u)
 }

--- a/internal/storage/contracts.go
+++ b/internal/storage/contracts.go
@@ -62,7 +62,7 @@ type Device struct {
 func NewStorage(uri string) (Storage, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error parsing storage uri")
+		return nil, errors.Wrap(err, "error parsing storage uri")
 	}
 
 	switch u.Scheme {

--- a/internal/storage/contracts_test.go
+++ b/internal/storage/contracts_test.go
@@ -57,5 +57,5 @@ func TestUnknownStorage(t *testing.T) {
 	s, err := NewStorage("foo://")
 	require.Nil(s)
 	require.Error(err)
-	require.Equal(err.Error(), "unknown storage backend foo")
+	require.Equal(err.Error(), "Unknown storage backend foo:")
 }

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 	// Set global log level
 	level, err := logrus.ParseLevel(*logLevel)
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "Invalid log level - should be one of fatal, error, warn, info, debug, trace"))
+		logrus.Fatal(errors.Wrap(err, "invalid log level - should be one of fatal, error, warn, info, debug, trace"))
 	}
 	logrus.SetLevel(level)
 	logrus.SetReportCaller(true)

--- a/pkg/authnz/authconfig/basic.go
+++ b/pkg/authnz/authconfig/basic.go
@@ -54,7 +54,7 @@ func basicAuthLogin(c *BasicAuthConfig, runtime *authruntime.ProviderRuntime) ht
 		// If we're here something went wrong, return StatusUnauthorized
 		w.Header().Set("WWW-Authenticate", `Basic realm="site"`)
 		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintln(w, "unauthorized")
+		fmt.Fprintln(w, "Unauthorized")
 	}
 }
 

--- a/pkg/authnz/authconfig/oidc.go
+++ b/pkg/authnz/authconfig/oidc.go
@@ -42,7 +42,7 @@ func (c *OIDCConfig) Provider() *authruntime.Provider {
 	ctx := context.Background()
 	provider, err := oidc.NewProvider(ctx, c.Issuer)
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "Failed to create OIDC provider"))
+		logrus.Fatal(errors.Wrap(err, "failed to create OIDC provider"))
 	}
 	verifier := provider.Verifier(&oidc.Config{ClientID: c.ClientID})
 
@@ -60,7 +60,7 @@ func (c *OIDCConfig) Provider() *authruntime.Provider {
 
 	redirectURL, err := url.Parse(c.RedirectURL)
 	if err != nil {
-		panic(errors.Wrapf(err, "Redirect URL is not valid: %s", c.RedirectURL))
+		panic(errors.Wrapf(err, "redirect URL is not valid: %s", c.RedirectURL))
 	}
 
 	return &authruntime.Provider{
@@ -123,7 +123,7 @@ func (c *OIDCConfig) callbackHandler(runtime *authruntime.ProviderRuntime, oauth
 		// 7. Client receives a response that contains an ID Token and Access Token in the response body.
 		oauth2Token, err := oauthConfig.Exchange(r.Context(), authCode)
 		if err != nil {
-			panic(errors.Wrap(err, "Unable to exchange tokens"))
+			panic(errors.Wrap(err, "unable to exchange tokens"))
 		}
 
 		// 8. Client validates the ID token and retrieves the End-User's Subject Identifier.
@@ -133,13 +133,13 @@ func (c *OIDCConfig) callbackHandler(runtime *authruntime.ProviderRuntime, oauth
 			logrus.Debug("Retrieving claims from UserInfo endpoint")
 			info, err := provider.UserInfo(r.Context(), oauthConfig.TokenSource(r.Context(), oauth2Token))
 			if err != nil {
-				panic(errors.Wrap(err, "Unable to get UserInfo"))
+				panic(errors.Wrap(err, "unable to get UserInfo"))
 			}
 
 			// Dump the claims
 			err = info.Claims(&oidcClaims)
 			if err != nil {
-				panic(errors.Wrap(err, "Unable to unmarshal claims from UserInfo JSON"))
+				panic(errors.Wrap(err, "unable to unmarshal claims from UserInfo JSON"))
 			}
 		} else {
 			// Extract and parse the ID token to retrieve the claims
@@ -151,13 +151,13 @@ func (c *OIDCConfig) callbackHandler(runtime *authruntime.ProviderRuntime, oauth
 			// Parse and verify ID Token payload
 			idToken, err := verifier.Verify(r.Context(), rawIDToken)
 			if err != nil {
-				panic(errors.Wrap(err, "Failed to verify ID token"))
+				panic(errors.Wrap(err, "failed to verify ID token"))
 			}
 
 			// Dump the claims
 			err = idToken.Claims(&oidcClaims)
 			if err != nil {
-				panic(errors.Wrap(err, "Unable to unmarshal claims from ID token JSON"))
+				panic(errors.Wrap(err, "unable to unmarshal claims from ID token JSON"))
 			}
 		}
 
@@ -262,7 +262,7 @@ func (r *ruleExpression) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	}
 	parsedRule, err := govaluate.NewEvaluableExpression(ruleStr)
 	if err != nil {
-		return errors.Wrap(err, "Unable to process OIDC rule")
+		return errors.Wrap(err, "unable to process OIDC rule")
 	}
 	ruleExpression := &ruleExpression{parsedRule}
 	*r = *ruleExpression

--- a/pkg/authnz/authconfig/oidc.go
+++ b/pkg/authnz/authconfig/oidc.go
@@ -42,7 +42,7 @@ func (c *OIDCConfig) Provider() *authruntime.Provider {
 	ctx := context.Background()
 	provider, err := oidc.NewProvider(ctx, c.Issuer)
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "failed to create oidc provider"))
+		logrus.Fatal(errors.Wrap(err, "Failed to create OIDC provider"))
 	}
 	verifier := provider.Verifier(&oidc.Config{ClientID: c.ClientID})
 
@@ -60,7 +60,7 @@ func (c *OIDCConfig) Provider() *authruntime.Provider {
 
 	redirectURL, err := url.Parse(c.RedirectURL)
 	if err != nil {
-		panic(errors.Wrapf(err, "redirect url is not valid: %s", c.RedirectURL))
+		panic(errors.Wrapf(err, "Redirect URL is not valid: %s", c.RedirectURL))
 	}
 
 	return &authruntime.Provider{
@@ -84,7 +84,7 @@ func (c *OIDCConfig) loginHandler(runtime *authruntime.ProviderRuntime, oauthCon
 			Nonce: &oauthStateString,
 		})
 		if err != nil {
-			http.Error(w, "no session", http.StatusUnauthorized)
+			http.Error(w, "No session", http.StatusUnauthorized)
 			return
 		}
 		// 2. Client sends the request to the Authorization Server.
@@ -103,17 +103,17 @@ func (c *OIDCConfig) callbackHandler(runtime *authruntime.ProviderRuntime, oauth
 
 		s, err := runtime.GetSession(r)
 		if err != nil {
-			http.Error(w, "no session", http.StatusBadRequest)
+			http.Error(w, "No session", http.StatusBadRequest)
 			return
 		}
 
 		// Make sure the returned state matches the one saved in the session cookie to prevent CSRF attacks
 		state := r.FormValue("state")
 		if s.Nonce == nil {
-			http.Error(w, "no state associated with session", http.StatusBadRequest)
+			http.Error(w, "No state associated with session", http.StatusBadRequest)
 			return
 		} else if *s.Nonce != state {
-			http.Error(w, "bad state value", http.StatusBadRequest)
+			http.Error(w, "Bad state value", http.StatusBadRequest)
 			return
 		}
 
@@ -130,7 +130,7 @@ func (c *OIDCConfig) callbackHandler(runtime *authruntime.ProviderRuntime, oauth
 		oidcClaims := make(map[string]interface{})
 		if !c.ClaimsFromIDToken {
 			// Use the UserInfo endpoint to retrieve the claims
-			logrus.Debug("retrieving claims from UserInfo endpoint")
+			logrus.Debug("Retrieving claims from UserInfo endpoint")
 			info, err := provider.UserInfo(r.Context(), oauthConfig.TokenSource(r.Context(), oauth2Token))
 			if err != nil {
 				panic(errors.Wrap(err, "Unable to get UserInfo"))
@@ -143,21 +143,21 @@ func (c *OIDCConfig) callbackHandler(runtime *authruntime.ProviderRuntime, oauth
 			}
 		} else {
 			// Extract and parse the ID token to retrieve the claims
-			logrus.Debug("retrieving claims from ID Token")
+			logrus.Debug("Retrieving claims from ID Token")
 			rawIDToken, ok := oauth2Token.Extra("id_token").(string)
 			if !ok {
-				panic(errors.New("No id_token field in oauth2 token"))
+				panic(errors.New("No id_token field in OAuth2 token"))
 			}
 			// Parse and verify ID Token payload
 			idToken, err := verifier.Verify(r.Context(), rawIDToken)
 			if err != nil {
-				panic(errors.Wrap(err, "Failed to verify ID Token"))
+				panic(errors.Wrap(err, "Failed to verify ID token"))
 			}
 
 			// Dump the claims
 			err = idToken.Claims(&oidcClaims)
 			if err != nil {
-				panic(errors.Wrap(err, "Unable to unmarshal claims from ID Token JSON"))
+				panic(errors.Wrap(err, "Unable to unmarshal claims from ID token JSON"))
 			}
 		}
 
@@ -213,7 +213,7 @@ func verifyEmailDomain(allowedDomains []string, email string) (string, bool) {
 
 	// check we have 2 parts i.e. <user>@<domain>
 	if len(parsed) != 2 {
-		return "missing or invalid email address", false
+		return "Missing or invalid email address", false
 	}
 
 	// match the domain against the list of allowed domains
@@ -223,7 +223,7 @@ func verifyEmailDomain(allowedDomains []string, email string) (string, bool) {
 		}
 	}
 
-	return "email domain not authorized", false
+	return "Email domain not authorized", false
 }
 
 // evaluateClaimMapping translates OIDC claims to custom authnz claims.
@@ -262,7 +262,7 @@ func (r *ruleExpression) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	}
 	parsedRule, err := govaluate.NewEvaluableExpression(ruleStr)
 	if err != nil {
-		return errors.Wrap(err, "Unable to process oidc rule")
+		return errors.Wrap(err, "Unable to process OIDC rule")
 	}
 	ruleExpression := &ruleExpression{parsedRule}
 	*r = *ruleExpression

--- a/pkg/authnz/authsession/session.go
+++ b/pkg/authnz/authsession/session.go
@@ -24,7 +24,7 @@ func GetSession(store sessions.Store, r *http.Request) (*AuthSession, error) {
 	if data, ok := session.Values[string(sessionKey)].([]byte); ok {
 		s := &AuthSession{}
 		if err := json.Unmarshal(data, s); err != nil {
-			return nil, errors.Wrap(err, "Failed to parse session")
+			return nil, errors.Wrap(err, "failed to parse session")
 		}
 		return s, nil
 	}
@@ -34,7 +34,7 @@ func GetSession(store sessions.Store, r *http.Request) (*AuthSession, error) {
 func SetSession(store sessions.Store, r *http.Request, w http.ResponseWriter, s *AuthSession) error {
 	data, err := json.Marshal(s)
 	if err != nil {
-		return errors.Wrap(err, "Failed to marshal session")
+		return errors.Wrap(err, "failed to marshal session")
 	}
 	session, _ := store.Get(r, string(sessionKey))
 	session.Values[string(sessionKey)] = data

--- a/pkg/authnz/authsession/session.go
+++ b/pkg/authnz/authsession/session.go
@@ -24,23 +24,28 @@ func GetSession(store sessions.Store, r *http.Request) (*AuthSession, error) {
 	if data, ok := session.Values[string(sessionKey)].([]byte); ok {
 		s := &AuthSession{}
 		if err := json.Unmarshal(data, s); err != nil {
-			return nil, errors.Wrap(err, "failed to parse session")
+			return nil, errors.Wrap(err, "Failed to parse session")
 		}
 		return s, nil
 	}
-	return nil, errors.New("session not authenticated")
+	return nil, errors.New("Session not authenticated")
 }
 
 func SetSession(store sessions.Store, r *http.Request, w http.ResponseWriter, s *AuthSession) error {
 	data, err := json.Marshal(s)
 	if err != nil {
-		return errors.Wrap(err, "failed to marshal session")
+		return errors.Wrap(err, "Failed to marshal session")
 	}
 	session, _ := store.Get(r, string(sessionKey))
 	session.Values[string(sessionKey)] = data
 	if err := session.Save(r, w); err != nil {
 		return err
 	}
+
+	if s.Identity != nil {
+		logrus.Infof("Creating web session with provider '%s' for user '%s' (remote address: %s)", s.Identity.Provider, s.Identity.Name, r.RemoteAddr)
+	}
+
 	return nil
 }
 
@@ -64,7 +69,7 @@ func CurrentUser(ctx context.Context) (*Identity, error) {
 			return session.Identity, nil
 		}
 	}
-	return nil, errors.New("unauthenticated")
+	return nil, errors.New("Unauthenticated")
 }
 
 func Authenticated(ctx context.Context) bool {

--- a/pkg/authnz/router.go
+++ b/pkg/authnz/router.go
@@ -54,7 +54,7 @@ func New(config authconfig.AuthConfig, claimsMiddleware authsession.ClaimsMiddle
 			return nil, err
 		}
 		if len(storeSecret) != 32 {
-			return nil, errors.New("session store secret must be 32 bytes long")
+			return nil, errors.New("Session store secret must be 32 bytes long")
 		}
 	}
 	store := sessions.NewCookieStore(storeSecret)
@@ -86,7 +86,7 @@ func New(config authconfig.AuthConfig, claimsMiddleware authsession.ClaimsMiddle
 		index, err := strconv.Atoi(mux.Vars(r)["index"])
 		if err != nil || index < 0 || len(providers) <= index {
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = fmt.Fprintf(w, "unknown provider")
+			_, _ = fmt.Fprintf(w, "Unknown provider")
 			return
 		}
 		provider := providers[index]


### PR DESCRIPTION
by:
- capitalizing log messages,
- adding additional logging, e.g. for user logins (session creation), and
- reducing the log level of these spammy grpc `info` lines to `debug`.

---

In our instance there are quite a lot of log lines like these:
```
INFO[0010]options.go:220 finished unary call with code OK              grpc.code=OK grpc.method=ListDevices grpc.service=proto.Devices grpc.start_time="2023-07-02T20:38:50+02:00" grpc.time_ms=0.258 span.kind=server system=grpc trace.id=a34950b0-b843-4844-b726-2b0abc543a70
```
By reducing their level to `debug` they are now filtered in the `info` setting.

What do you think?