### PR TITLE
Adds a device and user count the the all devices page.

### DIFF
--- a/website/src/pages/admin/AllDevices.tsx
+++ b/website/src/pages/admin/AllDevices.tsx
@@ -70,6 +70,7 @@ export const AllDevices = observer(class AllDevices extends React.Component {
 
         <Typography variant="h5" component="h5">
           Devices
+            <Typography component="span"> ({devices.filter(p => p.connected).length}  of {devices.length} online)</Typography>
         </Typography>
         <TableContainer>
           <Table stickyHeader>
@@ -119,6 +120,7 @@ export const AllDevices = observer(class AllDevices extends React.Component {
 
         <Typography variant="h5" component="h5">
             Users
+            <Typography component="span"> ({users.length})</Typography>
         </Typography>
         <TableContainer>
             <Table stickyHeader>


### PR DESCRIPTION
Adds an indicator for the number of devices (online vs total) and the number of users on the 'All Devices' page.

Before:
![2023-07-08_15-11](https://github.com/freifunkMUC/wg-access-server/assets/3245637/94d11afb-f6e5-4311-af59-9ff845f208ad)

After:
![2023-07-08_15-10](https://github.com/freifunkMUC/wg-access-server/assets/3245637/ca00a7f7-b4e5-47d3-ade3-66a473b4e9a1)

What do you think?