### PR TITLE
Gracefully terminates if configured OIDC auth server is not present on application start.

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -78,6 +78,14 @@ func (cmd *servecmd) Name() string {
 }
 
 func (cmd *servecmd) Run() {
+
+	// Swallow any panic stacktrace
+	defer func() {
+		if err := recover(); err != nil {
+			logrus.Fatal(err)
+		}
+	}()
+
 	conf := cmd.ReadConfig()
 
 	// Get the server's IP addresses within the VPN

--- a/pkg/authnz/authconfig/oidc.go
+++ b/pkg/authnz/authconfig/oidc.go
@@ -42,7 +42,7 @@ func (c *OIDCConfig) Provider() *authruntime.Provider {
 	ctx := context.Background()
 	provider, err := oidc.NewProvider(ctx, c.Issuer)
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "failed to create OIDC provider"))
+		panic(errors.Wrap(err, "failed to create OIDC provider"))
 	}
 	verifier := provider.Verifier(&oidc.Config{ClientID: c.ClientID})
 


### PR DESCRIPTION
Fixes #418.