### PR TITLE
Improves version feature to work in PRs as well as with branches/tags.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ github.head_ref }}
+            VERSION=${{ github.head_ref || github.ref_name }}
             COMMIT=${{ github.sha }}
 
       - name: Inspect Docker image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,5 +55,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ github.head_ref }}
+            VERSION=${{ github.head_ref || github.ref_name }}
             COMMIT=${{ github.sha }}


### PR DESCRIPTION
This `github.head_ref` only has content in PRs, so we need to cover the other branches/tags like `master`, or our version tags like `v1.2.3`. This is (presumably) done with the additional `github.ref_name`.