### PR TITLE
Hides GRPC request info logs

### DIFF
--- a/internal/services/api_router.go
+++ b/internal/services/api_router.go
@@ -76,9 +76,9 @@ func ApiRouter(deps *ApiServices) http.Handler {
 
 // GRPC events have the nature of DEBUG logs but are logged with INFO level. To clean up the log stream starting from INFO log level we only log WARN events.
 func grpcLoggerWith(ctx context.Context) *logrus.Entry {
-	if (logrus.GetLevel() == logrus.TraceLevel || logrus.GetLevel() == logrus.DebugLevel) {
-		return traces.Logger(ctx)
-	} else {
+	if (logrus.GetLevel() == logrus.InfoLevel) {
 		return traces.WarnLogger(ctx)
+	} else {
+		return traces.Logger(ctx)
 	}
 }

--- a/internal/traces/traces.go
+++ b/internal/traces/traces.go
@@ -25,7 +25,15 @@ func WithTraceID(ctx context.Context) context.Context {
 
 func Logger(ctx context.Context) *logrus.Entry {
 	return logrus.WithField("trace.id", TraceID(ctx))
+}
 
+// Creates a new instance of the logger which only logs WARNING events.
+// We use it as logger for the GRPC events which are hardcoded as INFO level and pollute the logs.
+func WarnLogger(ctx context.Context) *logrus.Entry {
+	warnLevel, _ := logrus.ParseLevel("warn")
+	warnLogger := logrus.New();
+	warnLogger.SetLevel(warnLevel)
+	return warnLogger.WithField("trace.id", TraceID(ctx))
 }
 
 func TraceID(ctx context.Context) string {

--- a/internal/traces/traces.go
+++ b/internal/traces/traces.go
@@ -30,9 +30,8 @@ func Logger(ctx context.Context) *logrus.Entry {
 // Creates a new instance of the logger which only logs WARNING events.
 // We use it as logger for the GRPC events which are hardcoded as INFO level and pollute the logs.
 func WarnLogger(ctx context.Context) *logrus.Entry {
-	warnLevel, _ := logrus.ParseLevel("warn")
-	warnLogger := logrus.New();
-	warnLogger.SetLevel(warnLevel)
+	warnLogger := logrus.New()
+	warnLogger.SetLevel(logrus.WarnLevel)
 	return warnLogger.WithField("trace.id", TraceID(ctx))
 }
 

--- a/main.go
+++ b/main.go
@@ -43,30 +43,10 @@ func main() {
 		},
 	})
 
-	// Hooks
-	logrus.AddHook(&GrpcInfoLogDemotionHook{})
-
 	for _, c := range commands {
 		if clicmd == c.Name() {
 			c.Run()
 			return
 		}
 	}
-}
-
-// Logrus hook for downgrading these 'finished unary call...' GRPC info logs to debug.
-type GrpcInfoLogDemotionHook struct {
-}
-
-func (h *GrpcInfoLogDemotionHook) Levels() []logrus.Level {
-	// Only concerns info entries.
-	return []logrus.Level{logrus.InfoLevel}
-}
-
-func (h *GrpcInfoLogDemotionHook) Fire(e *logrus.Entry) error {
-	// Demotes info log lines like `INFO[0010]options.go:220 finished unary call with code OK grpc.code=OK grpc.method=ListDevices...` to debug level.
-	if e.Data != nil && e.Data["system"] == "grpc" && e.Data["grpc.code"] == "OK" {
-		e.Level = logrus.DebugLevel
-	}
-	return nil
 }


### PR DESCRIPTION
So.. after I unsuccessfully tried to demote these GRPC `INFO` log statements to `DEBUG` level in #416 this is now my next try!
We are talking about these statements:
```
INFO[0011]options.go:220 finished unary call with code OK              grpc.code=OK grpc.method=ListAllDevices grpc.service=proto.Devices grpc.start_time="2023-09-09T14:28:41+02:00" grpc.time_ms=0.515 span.kind=server system=grpc trace.id=5b465b01-227c-4281-b2b2-966b4baa914c                    
INFO[0011]options.go:220 finished unary call with code OK              grpc.code=OK grpc.method=ListUsers grpc.service=proto.Users grpc.start_time="2023-09-09T14:28:41+02:00" grpc.time_ms=0.435 span.kind=server system=grpc trace.id=09ab9f84-aab1-4ed8-b5cf-2c960a996e2a
```
My position is that they should be actually of level `DEBUG` since they are not helpful for day to day operation of the wg-access-server and polluting the log.

---

My latest attempt: I create a second instance of the logrus logger with hardcoded level `WARN` and apply it to the GRPC calls if and only if the log level is higher than `TRACE` or `DEBUG`. The effect is that:
- the mentioned `INFO` log statements are not anymore shown if the log configuration is `info` or higher.
- if the log configuration is `debug` or `trace`, the GRPC statements are still shown.

I also removed the log hook again, as it only had cosmetic effect.

What do you think?
