### PR TITLE
Add package json name

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "npm-proj-1695147886070-0.16732827124090033nG1J9i",
+  "name": "wg-access-server-website",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "wg-access-server-website",
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.10.5",

--- a/website/package.json
+++ b/website/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "wg-access-server-website",
   "scripts": {
     "codegen": "node_modules/.bin/grpc-ts-web -o src/sdk ../proto/*.proto",
     "start": "react-scripts start",


### PR DESCRIPTION
On every JS library change this `name` item changed:
```
{
  "name": "npm-proj-1694749545477-0.4344903296934472580hq7g",
  "lockfileVersion": 2,
  "requires": true,
  "packages": {
...
```
and when building locally, it said:
```
  "name": "website",
  "lockfileVersion": 2,
  "requires": true,
  "packages": {
...
```
With the newly introduced property it should be constant.