### PR TITLE
fix: golang linter (io package)

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -3,7 +3,7 @@ package serve
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/netip"
@@ -302,7 +302,7 @@ func (cmd *servecmd) Run() {
 // ReadConfig reads the config file from disk if specified and overrides any env vars or cmdline options
 func (cmd *servecmd) ReadConfig() *config.AppConfig {
 	if cmd.ConfigFilePath != "" {
-		if b, err := ioutil.ReadFile(cmd.ConfigFilePath); err == nil {
+		if b, err := io.ReadFile(cmd.ConfigFilePath); err == nil {
 			if err := yaml.Unmarshal(b, &cmd.AppConfig); err != nil {
 				logrus.Fatal(errors.Wrap(err, "failed to bind configuration file"))
 			}

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -3,7 +3,6 @@ package serve
 import (
 	"context"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/netip"
@@ -302,7 +301,7 @@ func (cmd *servecmd) Run() {
 // ReadConfig reads the config file from disk if specified and overrides any env vars or cmdline options
 func (cmd *servecmd) ReadConfig() *config.AppConfig {
 	if cmd.ConfigFilePath != "" {
-		if b, err := io.ReadFile(cmd.ConfigFilePath); err == nil {
+		if b, err := os.ReadFile(cmd.ConfigFilePath); err == nil {
 			if err := yaml.Unmarshal(b, &cmd.AppConfig); err != nil {
 				logrus.Fatal(errors.Wrap(err, "failed to bind configuration file"))
 			}


### PR DESCRIPTION
Fixing
```
Error: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (staticcheck)
```