### PR TITLE
Add darkmode after login

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -8,7 +8,13 @@ import { grpc } from './Api';
 import { AppState } from './AppState';
 import { YourDevices } from './pages/YourDevices';
 import { AllDevices } from './pages/admin/AllDevices';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 
+const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+  },
+});
 export const App = observer(class App extends React.Component {
   async componentDidMount() {
     AppState.info = await grpc.server.info({});
@@ -20,18 +26,20 @@ export const App = observer(class App extends React.Component {
     }
     return (
       <Router>
-        <CssBaseline />
-        <Navigation />
-        <Box component="div" m={2}>
-          <Routes>
-            <Route path="/" element={<YourDevices />} />
-            {AppState.info.isAdmin && (
-              <>
-                <Route path="/admin/all-devices" element={<AllDevices />} />
-              </>
-            )}
-          </Routes>
-        </Box>
+        <ThemeProvider theme={darkTheme}>
+          <CssBaseline />
+          <Navigation />
+          <Box component="div" m={2}>
+            <Routes>
+              <Route path="/" element={<YourDevices />} />
+              {AppState.info.isAdmin && (
+                <>
+                  <Route path="/admin/all-devices" element={<AllDevices />} />
+                </>
+              )}
+            </Routes>
+          </Box>
+        </ThemeProvider>
       </Router>
     );
   }

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -10,11 +10,6 @@ import { YourDevices } from './pages/YourDevices';
 import { AllDevices } from './pages/admin/AllDevices';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 
-const darkTheme = createTheme({
-  palette: {
-    mode: 'dark',
-  },
-});
 export const App = observer(class App extends React.Component {
   async componentDidMount() {
     AppState.info = await grpc.server.info({});
@@ -24,9 +19,16 @@ export const App = observer(class App extends React.Component {
     if (!AppState.info) {
       return <p>loading...</p>;
     }
+
+    const darkLightTheme = createTheme({
+      palette: {
+        mode: AppState.darkMode ? 'dark' : 'light',
+      },
+    });
+
     return (
       <Router>
-        <ThemeProvider theme={darkTheme}>
+        <ThemeProvider theme={darkLightTheme}>
           <CssBaseline />
           <Navigation />
           <Box component="div" m={2}>

--- a/website/src/AppState.ts
+++ b/website/src/AppState.ts
@@ -1,13 +1,24 @@
-import { observable, makeObservable } from 'mobx';
+import {observable, makeObservable, runInAction} from 'mobx';
 import { InfoRes } from './sdk/server_pb';
 
 class GlobalAppState {
   info?: InfoRes.AsObject;
+  darkMode: boolean;
 
   constructor() {
     makeObservable(this, {
-      info: observable
+      info: observable,
+      darkMode: observable
     });
+
+    this.darkMode = false;
+  }
+
+  setDarkMode(darkMode: boolean) {
+    runInAction(() => {
+      this.darkMode = darkMode;
+    })
+
   }
 }
 

--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 import { getCookie } from '../Cookies';
 import { AppState } from '../AppState';
@@ -10,6 +10,10 @@ import Link from '@mui/material/Link';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import VpnKey from '@mui/icons-material/VpnKey';
+import IconButton from "@mui/material/IconButton";
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import Brightness7Icon from '@mui/icons-material/Brightness7';
+import {useMediaQuery} from "@mui/material";
 
 const useStyles = makeStyles((theme) => ({
   title: {
@@ -38,6 +42,8 @@ export default function Navigation() {
           )}
         </Typography>
 
+        <DarkModeToggle />
+
         {AppState.info?.isAdmin && (
           <Link to="/admin/all-devices" color="inherit" component={NavLink}>
             <Button color="inherit">All Devices</Button>
@@ -52,4 +58,40 @@ export default function Navigation() {
       </Toolbar>
     </AppBar>
   );
+}
+
+function DarkModeToggle() {
+
+  const CUSTOM_DARK_MODE_KEY = "customDarkMode";
+  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+
+  useEffect(()=>{
+    let customDarkMode = localStorage.getItem(CUSTOM_DARK_MODE_KEY);
+      if (customDarkMode) {
+        AppState.setDarkMode(JSON.parse(customDarkMode));
+      }
+      else {
+        AppState.setDarkMode(prefersDarkMode);
+      }
+
+    },[prefersDarkMode]);
+
+  function toggleDarkMode() {
+    AppState.setDarkMode(!AppState.darkMode);
+
+    // We only persist the preference in the local storage if it is different to the OS setting.
+    if (prefersDarkMode !== AppState.darkMode) {
+      localStorage.setItem(CUSTOM_DARK_MODE_KEY, JSON.stringify(AppState.darkMode));
+    }
+    else {
+      localStorage.removeItem(CUSTOM_DARK_MODE_KEY);
+    }
+  }
+
+  return (
+      <IconButton sx={{ ml: 1 }} onClick={toggleDarkMode} color="inherit" title={"Light / Dark"}>
+        {AppState.darkMode ? <Brightness7Icon /> : <Brightness4Icon />}
+      </IconButton>
+  );
+
 }

--- a/website/src/components/Present.tsx
+++ b/website/src/components/Present.tsx
@@ -4,6 +4,8 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { AppState } from '../AppState';
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 
@@ -20,7 +22,14 @@ export function present<T>(content: (close: (result: T) => void) => React.ReactN
 }
 
 export function confirm(msg: string): Promise<boolean> {
+  const darkLightTheme = createTheme({
+    palette: {
+      mode: AppState.darkMode ? 'dark' : 'light',
+    },
+  });
+
   return present<boolean>((close) => (
+    <ThemeProvider theme={darkLightTheme}>
     <Dialog open={true} onClose={() => close(false)}>
       <DialogTitle>Confirm</DialogTitle>
       <DialogContent>
@@ -35,5 +44,6 @@ export function confirm(msg: string): Promise<boolean> {
         </Button>
       </DialogActions>
     </Dialog>
+    </ThemeProvider>
   ));
 }


### PR DESCRIPTION
added darkmode but atm only darkmode, no light mode:
i tried this form the Docs:
https://mui.com/material-ui/customization/dark-mode/#system-preference
but it did not work for me 

maybe add also a toggle like:
https://mui.com/material-ui/customization/dark-mode/#toggling-color-mode



"/"
![image](https://github.com/freifunkMUC/wg-access-server/assets/5702338/48172a4e-6b72-49c4-a4c0-4867ea32e1b3)

"/admin/all-devices"  
![image](https://github.com/freifunkMUC/wg-access-server/assets/5702338/cdb4db1f-cf33-4a77-a95b-cec0a21b903a)

"Popup"
![image](https://github.com/freifunkMUC/wg-access-server/assets/5702338/3d41985d-fdf6-44bf-8ff3-54540224d511)
  
![image](https://github.com/freifunkMUC/wg-access-server/assets/5702338/1d5935f2-6b81-4570-8327-f3d58e9f1901)

