### PR TITLE
Updates `golangci-lint-action` to v4.

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,7 +10,7 @@ on:
 jobs: # Docs: <https://git.io/JvxXE>
   gitleaks:
     name: Gitleaks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with: {fetch-depth: 0}
@@ -21,14 +21,18 @@ jobs: # Docs: <https://git.io/JvxXE>
 
   golangci-lint:
     name: Golang-CI (lint)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with: {fetch-depth: 0}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.20'
+          cache: false
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v3.7.0 # Action page: <https://github.com/golangci/golangci-lint-action>
+        uses: golangci/golangci-lint-action@v4 # Action page: <https://github.com/golangci/golangci-lint-action>
         with:
-          version: v1.52 # without patch version
+          version: v1.56 # without patch version
           only-new-issues: false # show only new issues if it's a pull request
           args: --timeout 4m # the default of 1m didn't suffice occasionally


### PR DESCRIPTION
We are experiencing issues with the go linter, let's have a look if we can improve the situation with an upgrade.