### PR TITLE
add signin and signout for Development

### DIFF
--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -14,6 +14,7 @@ import IconButton from "@mui/material/IconButton";
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import LogoutIcon from '@mui/icons-material/Logout';
+import LoginIcon from '@mui/icons-material/Login';
 import {useMediaQuery} from "@mui/material";
 
 const useStyles = makeStyles((theme) => ({
@@ -54,10 +55,16 @@ export default function Navigation() {
           </Link>
         )}
 
-        {hasAuthCookie && (
+        {hasAuthCookie ? (
           <Link href="/signout" color="inherit">
-            <IconButton sx={{ ml: 1 }}  color="inherit" title="Logout">
+            <IconButton sx={{ ml: 1 }} color="inherit" title="Logout">
               <LogoutIcon /> 
+            </IconButton>
+          </Link>
+        ) : (
+          <Link href="/signin" color="inherit">
+            <IconButton sx={{ ml: 1 }} color="inherit" title="Login">
+              <LoginIcon /> 
             </IconButton>
           </Link>
         )}

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -15,6 +15,16 @@ export default defineConfig({
                 target: 'http://localhost:8000',
                 changeOrigin: true,
                 secure: false
+            },
+            '/signin': {
+                target: 'http://localhost:8000',
+                changeOrigin: true,
+                secure: false
+            },
+            '/signout': {
+                target: 'http://localhost:8000',
+                changeOrigin: true,
+                secure: false
             }
         }
     }


### PR DESCRIPTION
add `/signin` and `/signout`
also added Sign in Button

![image](https://github.com/freifunkMUC/wg-access-server/assets/5702338/3553c171-a628-4d20-9156-3e44c8352b69)


After logging in via "/signin", I receive
![image](https://github.com/freifunkMUC/wg-access-server/assets/5702338/30b9de31-5d19-4fbe-bc96-1680be989f9b)
However, if I reload the page normally, I gain access to it.


