### PR TITLE
temporary downgrade image ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   push_to_registry:
     name: Push Docker image to GitHub Packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
temporary downgrade image ci to `ubuntu-22.04`
failes some how for `linux/arm64/v8`

failes:
![image](https://github.com/user-attachments/assets/9e8ebd2b-f70a-4eab-b06d-f53062edb87e)


Succes:
![image](https://github.com/user-attachments/assets/7c071e20-79ec-4d3f-aa69-ed39c9833dda)
