### PR TITLE
fix: prevent white flash by initializing dark mode from system preference

### DIFF
--- a/website/src/AppState.ts
+++ b/website/src/AppState.ts
@@ -13,7 +13,10 @@ class GlobalAppState {
       loadingError: observable,
     });
 
-    this.darkMode = false;
+    const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const storedDarkMode = localStorage.getItem('customDarkMode');
+    
+    this.darkMode = storedDarkMode !== null ? JSON.parse(storedDarkMode) : prefersDarkMode;
   }
 
   setDarkMode(darkMode: boolean) {


### PR DESCRIPTION
Initialize dark mode state during app startup using system preferences and stored user settings to prevent momentary white flash on page load. Previously, dark mode was always initialized as false before checking preferences.