### PR TITLE
feat: add HTTPS support for web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ website/yarn-error.log*
 website/yarn.lock
 
 __debug_bin
+
+#Certificates
+*.crt
+*.key

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN go build -o wg-access-server
 
 ### Server
 FROM alpine:3.21.3
-RUN apk add --no-cache iptables ip6tables wireguard-tools curl
+RUN apk add --no-cache iptables ip6tables wireguard-tools curl openssl
 ENV WG_CONFIG="/config.yaml"
 ENV WG_STORAGE="sqlite3:///data/db.sqlite3"
 COPY --from=server /code/wg-access-server /usr/local/bin/wg-access-server

--- a/README.md
+++ b/README.md
@@ -63,16 +63,16 @@ docker run \
   -v /lib/modules:/lib/modules:ro \
   -e "WG_ADMIN_PASSWORD=$WG_ADMIN_PASSWORD" \
   -e "WG_WIREGUARD_PRIVATE_KEY=$WG_WIREGUARD_PRIVATE_KEY" \
-  -p 8000:8000/tcp \
+  -p 8443:8443/tcp \
   -p 51820:51820/udp \
   ghcr.io/freifunkmuc/wg-access-server:latest
 ```
 
 **Note:** This command includes the `SYS_MODULE` capability which essentially gives the container root privileges over the host system and an attacker could easily break out of the container. See the [Docker instructions](https://www.freie-netze.org/wg-access-server/deployment/1-docker/) for the recommended way to run the container.
 
-If the wg-access-server is accessible via LAN or a network you are in, you can directly connect your phone to the VPN. You have to call the webfrontent of the project for this. Normally, this is done via the IP address of the device or server on which the wg-access-server is running followed by the standard port 8000, via which the web interface can be reached. For most deployments something like this should work: http://192.168.0.XX:8000
+If the wg-access-server is accessible via LAN or a network you are in, you can directly connect your phone to the VPN. You have to call the webfrontent of the project for this. Normally, this is done via the IP address of the device or server on which the wg-access-server is running followed by the standard port 8443, via which the web interface can be reached. For most deployments something like this should work: https://192.168.0.XX:8443
 
-If the project is running locally on the computer, you can easily connect to the web interface by connecting to http://localhost:8000 in the browser.
+If the project is running locally on the computer, you can easily connect to the web interface by connecting to https://localhost:8443 in the browser.
 
 ## Running with Docker-Compose
 
@@ -88,7 +88,7 @@ echo "Your automatically generated admin password for the wg-access-server's web
 docker-compose up
 ```
 
-You can connect to the web server on the local machine browser at http://localhost:8000
+You can connect to the web server on the local machine browser at https://localhost:8443
 
 If you open your browser to your machine's LAN IP address you'll be able
 to connect your phone using the UI and QR code!
@@ -130,7 +130,7 @@ The software consists of a Golang server and a React app.
 If you want to make changes to the project locally, you can do so relatively easily with the following steps.
 
 1. Run `cd website && npm install && npm start` to get the frontend running on `:3000`.
-2. Run `sudo go run ./main.go` to get the server running on `:8000`.
+2. Run `sudo go run ./main.go serve` to get the server running on http: `:8000` and https: `:8443`.
 
 Here are some notes on development configuration:
 

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -48,6 +48,10 @@ func Register(app *kingpin.Application) *servecmd {
 	cli.Flag("enable-inactive-device-deletion", "Enable inactive device deletion").Envar("WG_ENABLE_INACTIVE_DEVICE_DELETION").Default("false").BoolVar(&cmd.AppConfig.EnableInactiveDeviceDeletion)
 	cli.Flag("inactive-device-grace-period", "Duration after inactive device are deleted").Envar("WG_INACTIVE_DEVICE_GRACE_PERIOD").Default((1 * config.Year).String()).DurationVar(&cmd.AppConfig.InactiveDeviceGracePeriod)
 	cli.Flag("filename", "The configuration filename (e.g. WireGuard-Home)").Envar("WG_FILENAME").StringVar(&cmd.AppConfig.Filename)
+	cli.Flag("https-enabled", "Enable HTTPS for the web UI").Envar("WG_HTTPS_ENABLED").Default("true").BoolVar(&cmd.AppConfig.HTTPS.Enabled)
+	cli.Flag("https-cert-file", "Path to the TLS certificate file").Envar("WG_HTTPS_CERT_FILE").StringVar(&cmd.AppConfig.HTTPS.CertFile)
+	cli.Flag("https-key-file", "Path to the TLS private key file").Envar("WG_HTTPS_KEY_FILE").StringVar(&cmd.AppConfig.HTTPS.KeyFile)
+	cli.Flag("https-port", "Port for HTTPS server").Envar("WG_HTTPS_PORT").Default("8443").IntVar(&cmd.AppConfig.HTTPS.Port)
 	cli.Flag("wireguard-enabled", "Enable or disable the embedded wireguard server (useful for development)").Envar("WG_WIREGUARD_ENABLED").Default("true").BoolVar(&cmd.AppConfig.WireGuard.Enabled)
 	cli.Flag("wireguard-interface", "Set the wireguard interface name").Default("wg0").Envar("WG_WIREGUARD_INTERFACE").StringVar(&cmd.AppConfig.WireGuard.Interface)
 	cli.Flag("wireguard-private-key", "Wireguard private key").Envar("WG_WIREGUARD_PRIVATE_KEY").StringVar(&cmd.AppConfig.WireGuard.PrivateKey)
@@ -269,32 +273,75 @@ func (cmd *servecmd) Run() {
 
 	// Listen
 	address := fmt.Sprintf(":%d", conf.Port)
-	srv := &http.Server{
+
+	// Create a new HTTP server
+	httpSrv := &http.Server{
 		Addr:    address,
 		Handler: publicRouter,
 	}
 
+	// Start HTTP server
 	go func() {
-		// Start Web server
-		logrus.Infof("Web UI listening on %v", address)
-		err := srv.ListenAndServe()
+		logrus.Infof("Web UI listening on http://%v", address)
+		err := httpSrv.ListenAndServe()
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errChan <- errors.Wrap(err, "unable to start http server")
 		}
 	}()
 
+	// Start HTTPS server if enabled
+	var httpsSrv *http.Server
+	if conf.HTTPS.Enabled {
+		// Determine HTTPS port
+		httpsAddress := fmt.Sprintf(":%d", conf.HTTPS.Port)
+
+		// Determine certificate paths
+		certPath := conf.HTTPS.CertFile
+		keyPath := conf.HTTPS.KeyFile
+		if certPath == "" || keyPath == "" {
+			certPath, keyPath = services.GetDefaultCertPaths()
+		}
+
+		// Load TLS certificate
+		tlsConfig, err := services.LoadTLSCert(certPath, keyPath)
+		if err != nil {
+			logrus.Error(errors.Wrap(err, "failed to load TLS certificate"))
+			return
+		}
+
+		// Create HTTPS server
+		httpsSrv = &http.Server{
+			Addr:      httpsAddress,
+			Handler:   publicRouter,
+			TLSConfig: tlsConfig,
+		}
+
+		// Start HTTPS server
+		go func() {
+			logrus.Infof("Web UI listening on https://%v", httpsAddress)
+			err := httpsSrv.ListenAndServeTLS("", "") // Cert and key are already in TLSConfig
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				errChan <- errors.Wrap(err, "unable to start https server")
+			}
+		}()
+	}
+
 	select {
 	case <-signalChan:
-		ctx := context.Background()
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		err = srv.Shutdown(ctx)
-		if err != nil {
-			logrus.Error(err)
+		// Shutdown logic
+		logrus.Info("shutting down server...")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := httpSrv.Shutdown(ctx); err != nil {
+			logrus.Error(errors.Wrap(err, "unable to shutdown http server"))
 		}
-		cancel() // always call cancel to clean up the context
-	case err = <-errChan:
+		if httpsSrv != nil {
+			if err := httpsSrv.Shutdown(ctx); err != nil {
+				logrus.Error(errors.Wrap(err, "unable to shutdown https server"))
+			}
+		}
+	case err := <-errChan:
 		logrus.Error(err)
-		return
 	}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     #  - "WG_VPN_CIDRV6=0" # to disable IPv6
     ports:
       - "8000:8000/tcp"
+      - "8443:8443/tcp"
       - "51820:51820/udp"
     devices:
       - "/dev/net/tun:/dev/net/tun"

--- a/docs/2-configuration.md
+++ b/docs/2-configuration.md
@@ -58,6 +58,10 @@ Here's what you can configure:
 | `WG_CLIENTCONFIG_DNS_SERVERS`        | `--clientconfig-dns-servers`        | `clientConfig.dnsServers`      |          |                                              | DNS servers (one or more IP addresses) to write into the client configuration file. Are used instead of the servers DNS settings, if set.                                                                                                                                     |
 | `WG_CLIENTCONFIG_DNS_SEARCH_DOMAIN`  | `--clientconfig-dns-search-domain`  | `clientConfig.dnsSearchDomain` |          |                                              | DNS search domain to write into the client configuration file.                                                                                                                                                                                                                |
 | `WG_CLIENTCONFIG_MTU`                | `--clientconfig-mtu`                | `clientConfig.mtu`             |          |                                              | The maximum transmission unit (MTU) to write into the client configuration file. If left empty, a sensible default is used.                                                                                                                                                   |
+| `WG_HTTPS_ENABLED`                   | `--https-enabled`                   | `https.enabled`                |          | `true`                                       | Enable HTTPS for the web UI.                                                                                                                                                                                                                                                  |
+| `WG_HTTPS_CERT_FILE`                 | `--https-cert-file`                 | `https.certFile`               |          |                                              | Path to the TLS certificate file. If not provided, a self-signed certificate will be generated.                                                                                                                                                                               |
+| `WG_HTTPS_KEY_FILE`                  | `--https-key-file`                  | `https.keyFile`                |          |                                              | Path to the TLS private key file. If not provided, a self-signed certificate will be generated.                                                                                                                                                                               |
+| `WG_HTTPS_PORT`                      | `--https-port`                      | `https.port`                   |          | 8443                                         | Port for HTTPS server.                                                                                                                                                                                                                                                     |
 
 
 ## The Config File (config.yaml)
@@ -67,10 +71,39 @@ Here's an example config file to get started with.
 ```yaml
 loglevel: info
 storage: sqlite3:///data/db.sqlite3
+adminPassword: "admin"
+port: 8000
+externalHost: "example.com"
 wireguard:
-  privateKey: "<some-key>"
+  enabled: true
+  interface: wg0
+  privateKey: "your-private-key"
+  port: 51820
+  mtu: 1420
+vpn:
+  allowedIPs:
+    - "0.0.0.0/0"
+    - "::/0"
+  cidr: "10.44.0.0/24"
+  cidrv6: "fd48:4c4:7aa9::/64"
+  gatewayInterface: "eth0"
+  nat44: true
+  nat66: true
+  clientIsolation: false
 dns:
+  enabled: true
   upstream:
-    - "2001:4860:4860::8888"
-    - "8.8.8.8"
+    - "1.1.1.1"
+    - "2606:4700:4700::1111"
+  domain: "vpn.home.arpa."
+clientConfig:
+  dnsServers:
+    - "10.44.0.1"
+  dnsSearchDomain: "vpn.home.arpa."
+  mtu: 1420
+https:
+  enabled: true
+  certFile: "/path/to/cert.pem"
+  keyFile: "/path/to/key.pem"
+  port: 8443
 ```

--- a/docs/2-configuration.md
+++ b/docs/2-configuration.md
@@ -71,39 +71,9 @@ Here's an example config file to get started with.
 ```yaml
 loglevel: info
 storage: sqlite3:///data/db.sqlite3
-adminPassword: "admin"
-port: 8000
-externalHost: "example.com"
 wireguard:
-  enabled: true
-  interface: wg0
-  privateKey: "your-private-key"
-  port: 51820
-  mtu: 1420
-vpn:
-  allowedIPs:
-    - "0.0.0.0/0"
-    - "::/0"
-  cidr: "10.44.0.0/24"
-  cidrv6: "fd48:4c4:7aa9::/64"
-  gatewayInterface: "eth0"
-  nat44: true
-  nat66: true
-  clientIsolation: false
+  privateKey: "<some-key>"
 dns:
-  enabled: true
   upstream:
-    - "1.1.1.1"
-    - "2606:4700:4700::1111"
-  domain: "vpn.home.arpa."
-clientConfig:
-  dnsServers:
-    - "10.44.0.1"
-  dnsSearchDomain: "vpn.home.arpa."
-  mtu: 1420
-https:
-  enabled: true
-  certFile: "/path/to/cert.pem"
-  keyFile: "/path/to/key.pem"
-  port: 8443
-```
+    - "2001:4860:4860::8888"
+    - "8.8.8.8"

--- a/docs/deployment/2-docker-compose.md
+++ b/docs/deployment/2-docker-compose.md
@@ -32,6 +32,7 @@ services:
     environment:
       - "WG_ADMIN_PASSWORD=${WG_ADMIN_PASSWORD:?\n\nplease set the WG_ADMIN_PASSWORD environment variable:\n    export WG_ADMIN_PASSWORD=example\n}"
       - "WG_WIREGUARD_PRIVATE_KEY=${WG_WIREGUARD_PRIVATE_KEY:?\n\nplease set the WG_WIREGUARD_PRIVATE_KEY environment variable:\n    export WG_WIREGUARD_PRIVATE_KEY=$(wg genkey)\n}"
+      - "WG_HTTPS_ENABLED=false"
     #  - "WG_VPN_CIDRV6=0" # to disable IPv6
     expose:
       - "8000/tcp"
@@ -92,6 +93,7 @@ services:
       - "WG_VPN_CIDR=0" # to disable IPv4
     ports:
       - "8000:8000/tcp"
+      - "8443:8443/tcp"
       - "51820:51820/udp"
     devices:
       - "/dev/net/tun:/dev/net/tun"
@@ -119,6 +121,7 @@ services:
       - "WG_VPN_CIDRV6=0" # to disable IPv6
     ports:
       - "8000:8000/tcp"
+      - "8443:8443/tcp"
       - "51820:51820/udp"
     devices:
       - "/dev/net/tun:/dev/net/tun"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,4 +153,19 @@ type AppConfig struct {
 	// If no authentication backends are configured then
 	// the server will not require any authentication.
 	Auth authconfig.AuthConfig `yaml:"auth"`
+	// HTTPS configuration
+	HTTPS struct {
+		// Enable HTTPS for the web UI
+		// Defaults to true
+		Enabled bool `yaml:"enabled"`
+		// Path to the TLS certificate file
+		// If not provided, a self-signed certificate will be generated
+		CertFile string `yaml:"certFile"`
+		// Path to the TLS private key file
+		// If not provided, a self-signed certificate will be generated
+		KeyFile string `yaml:"keyFile"`
+		// Port for HTTPS server
+		// Defaults to 8443
+		Port int `yaml:"port"`
+	} `yaml:"https"`
 }

--- a/internal/services/tls.go
+++ b/internal/services/tls.go
@@ -1,0 +1,121 @@
+package services
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// GenerateSelfSignedCert generates a self-signed certificate and key
+// and saves them to the specified paths
+func GenerateSelfSignedCert(certPath, keyPath string) error {
+	// Create directory if it doesn't exist
+	certDir := filepath.Dir(certPath)
+	if err := os.MkdirAll(certDir, 0755); err != nil {
+		return errors.Wrap(err, "failed to create certificate directory")
+	}
+
+	// Generate private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return errors.Wrap(err, "failed to generate private key")
+	}
+
+	// Create certificate template
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"WG Access Server"},
+			CommonName:   "WG Access Server Self-Signed Certificate",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0), // Valid for 10 years
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:              []string{"localhost"},
+	}
+
+	// Create certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to create certificate")
+	}
+
+	// Encode certificate to PEM
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	// Encode private key to PEM
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	// Write certificate to file
+	if err := os.WriteFile(certPath, certPEM, 0644); err != nil {
+		return errors.Wrap(err, "failed to write certificate file")
+	}
+
+	// Write private key to file
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		return errors.Wrap(err, "failed to write private key file")
+	}
+
+	logrus.Infof("Generated self-signed certificate: %s", certPath)
+	logrus.Infof("Generated private key: %s", keyPath)
+
+	return nil
+}
+
+// LoadTLSCert loads a TLS certificate from the specified paths
+// If the certificate doesn't exist, it generates a self-signed one
+func LoadTLSCert(certPath, keyPath string) (*tls.Config, error) {
+	// Check if certificate and key exist
+	_, certErr := os.Stat(certPath)
+	_, keyErr := os.Stat(keyPath)
+
+	// If either file doesn't exist, generate a self-signed certificate
+	if os.IsNotExist(certErr) || os.IsNotExist(keyErr) {
+		logrus.Info("Certificate or key not found, generating self-signed certificate")
+		if err := GenerateSelfSignedCert(certPath, keyPath); err != nil {
+			return nil, err
+		}
+	}
+
+	// Load certificate
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load TLS certificate")
+	}
+
+	// Create TLS config
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:  tls.VersionTLS12,
+	}
+
+	return tlsConfig, nil
+}
+
+// GetDefaultCertPaths returns the default paths for the certificate and key
+func GetDefaultCertPaths() (string, string) {
+	// Use the current directory as the default location
+	certPath := "wg-access-server.crt"
+	keyPath := "wg-access-server.key"
+	return certPath, keyPath
+} 


### PR DESCRIPTION
- Updated Dockerfile to include OpenSSL for HTTPS support.
- Enhanced main.go to configure and start an HTTPS server with TLS certificate handling.
- Added new configuration options for HTTPS in config.go and updated documentation to reflect these changes.
- Implemented self-signed certificate generation in tls.go if no certificate is provided.

This enable HTTPS for the web UI, improving security for web traffic, also allows users to disable https example if the use a reverse Proxy.

https starts on default port 8443
`https://localhost:8443/`
http stats on default port 8000
`http://localhost:8000/`

Own TLS file:
```cmd
go run main.go serve --admin-password=test --https-cert-file local.crt --https-key-file local.key
```
No HTTPS:
```cmd
sudo go run main.go serve --admin-password=test --no-https-enabled
```

![image](https://github.com/user-attachments/assets/c9dd28a4-3ed9-4068-b3cc-022a13927986)
![image](https://github.com/user-attachments/assets/d13a54c4-52de-4849-b904-801078673e2b)

