### PR TITLE
fix(storage): guard in-memory store to prevent concurrent map crash

### DIFF
--- a/internal/storage/inmemory.go
+++ b/internal/storage/inmemory.go
@@ -3,11 +3,13 @@ package storage
 import (
 	"errors"
 	"strings"
+	"sync"
 )
 
 // implements Storage interface
 type InMemoryStorage struct {
 	*InProcessWatcher
+	mu sync.RWMutex
 	db map[string]*Device
 }
 
@@ -28,12 +30,22 @@ func (s *InMemoryStorage) Close() error {
 }
 
 func (s *InMemoryStorage) Save(device *Device) error {
+	s.mu.Lock()
 	s.db[key(device)] = device
+	s.mu.Unlock()
 	s.EmitAdd(device)
 	return nil
 }
 
 func (s *InMemoryStorage) List(username string) ([]*Device, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.list(username), nil
+}
+
+// list returns all devices for the given username (or all devices if
+// username is empty). Callers must hold s.mu.
+func (s *InMemoryStorage) list(username string) []*Device {
 	devices := []*Device{}
 	prefix := func() string {
 		if username != "" {
@@ -46,10 +58,12 @@ func (s *InMemoryStorage) List(username string) ([]*Device, error) {
 			devices = append(devices, device)
 		}
 	}
-	return devices, nil
+	return devices
 }
 
 func (s *InMemoryStorage) Get(owner string, name string) (*Device, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	device, ok := s.db[keyStr(owner, name)]
 	if !ok {
 		return nil, errors.New("device doesn't exist")
@@ -58,11 +72,9 @@ func (s *InMemoryStorage) Get(owner string, name string) (*Device, error) {
 }
 
 func (s *InMemoryStorage) GetByPublicKey(publicKey string) (*Device, error) {
-	devices, err := s.List("")
-	if err != nil {
-		return nil, err
-	}
-	for _, device := range devices {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, device := range s.list("") {
 		if device.PublicKey == publicKey {
 			return device, nil
 		}
@@ -71,7 +83,9 @@ func (s *InMemoryStorage) GetByPublicKey(publicKey string) (*Device, error) {
 }
 
 func (s *InMemoryStorage) Delete(device *Device) error {
+	s.mu.Lock()
 	delete(s.db, key(device))
+	s.mu.Unlock()
 	s.EmitDelete(device)
 	return nil
 }

--- a/internal/storage/inmemory_race_test.go
+++ b/internal/storage/inmemory_race_test.go
@@ -1,0 +1,144 @@
+package storage
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// TestInMemoryStorageConcurrentAccess hammers a single InMemoryStorage with
+// concurrent writers and readers. Before InMemoryStorage was guarded by a
+// mutex this crashed with a fatal "concurrent map read and map write" runtime
+// error (and is reliably flagged by `go test -race`), because the metadata
+// sync goroutine calls Save while gRPC handlers read via List/Get/
+// GetByPublicKey.
+func TestInMemoryStorageConcurrentAccess(t *testing.T) {
+	const (
+		iterations = 500
+		owners     = 2
+		names      = 10
+	)
+
+	s := NewMemoryStorage()
+
+	// exercise the watcher path too: EmitAdd/EmitDelete run on every
+	// Save/Delete and must be safe when called from many goroutines
+	var adds, deletes int64
+	s.OnAdd(func(d *Device) {
+		if d == nil {
+			t.Error("OnAdd called with nil device")
+		}
+		atomic.AddInt64(&adds, 1)
+	})
+	s.OnDelete(func(d *Device) {
+		if d == nil {
+			t.Error("OnDelete called with nil device")
+		}
+		atomic.AddInt64(&deletes, 1)
+	})
+
+	owner := func(i int) string { return fmt.Sprintf("user%d", i%owners) }
+	name := func(i int) string { return fmt.Sprintf("device%d", i%names) }
+	publicKey := func(i int) string { return fmt.Sprintf("pub-%s-%s", owner(i), name(i)) }
+
+	var wg sync.WaitGroup
+	run := func(fn func(i int)) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				fn(i)
+			}
+		}()
+	}
+
+	// writers
+	for g := 0; g < 4; g++ {
+		run(func(i int) {
+			err := s.Save(&Device{
+				Owner:     owner(i),
+				Name:      name(i),
+				PublicKey: publicKey(i),
+				Address:   "10.44.0.2/32",
+			})
+			if err != nil {
+				t.Errorf("Save failed: %v", err)
+			}
+		})
+	}
+
+	// deleters
+	for g := 0; g < 2; g++ {
+		run(func(i int) {
+			err := s.Delete(&Device{Owner: owner(i), Name: name(i)})
+			if err != nil {
+				t.Errorf("Delete failed: %v", err)
+			}
+		})
+	}
+
+	// readers
+	run(func(i int) {
+		if _, err := s.List(""); err != nil {
+			t.Errorf("List(\"\") failed: %v", err)
+		}
+	})
+	run(func(i int) {
+		if _, err := s.List(owner(i)); err != nil {
+			t.Errorf("List(%q) failed: %v", owner(i), err)
+		}
+	})
+	run(func(i int) {
+		// Get legitimately errors when the device is currently deleted;
+		// we only care that it doesn't crash or race
+		_, _ = s.Get(owner(i), name(i))
+	})
+	run(func(i int) {
+		_, _ = s.GetByPublicKey(publicKey(i))
+	})
+
+	wg.Wait()
+
+	// sanity-check the final state: the keyspace is bounded, so the store
+	// can never contain more than owners*names devices
+	devices, err := s.List("")
+	if err != nil {
+		t.Fatalf("List after concurrent access failed: %v", err)
+	}
+	if len(devices) > owners*names {
+		t.Fatalf("expected at most %d devices, got %d", owners*names, len(devices))
+	}
+	for _, d := range devices {
+		if d == nil {
+			t.Fatal("List returned a nil device")
+		}
+	}
+
+	if got := atomic.LoadInt64(&adds); got != 4*iterations {
+		t.Fatalf("expected %d OnAdd events, got %d", 4*iterations, got)
+	}
+	if got := atomic.LoadInt64(&deletes); got != 2*iterations {
+		t.Fatalf("expected %d OnDelete events, got %d", 2*iterations, got)
+	}
+
+	// the store must still be fully usable afterwards
+	sentinel := &Device{Owner: "sentinel", Name: "laptop", PublicKey: "sentinel-pub"}
+	if err := s.Save(sentinel); err != nil {
+		t.Fatalf("Save after concurrent access failed: %v", err)
+	}
+	got, err := s.Get("sentinel", "laptop")
+	if err != nil {
+		t.Fatalf("Get after concurrent access failed: %v", err)
+	}
+	if got.PublicKey != "sentinel-pub" {
+		t.Fatalf("expected public key %q, got %q", "sentinel-pub", got.PublicKey)
+	}
+	byKey, err := s.GetByPublicKey("sentinel-pub")
+	if err != nil {
+		t.Fatalf("GetByPublicKey after concurrent access failed: %v", err)
+	}
+	if byKey.Owner != "sentinel" || byKey.Name != "laptop" {
+		t.Fatalf("GetByPublicKey returned wrong device: %s/%s", byKey.Owner, byKey.Name)
+	}
+}


### PR DESCRIPTION
InMemoryStorage's device map was accessed without any synchronization. Each API request is served in its own goroutine, so two concurrent calls from a single authenticated non-admin user are enough to race: AddDevice and DeleteDevice write the map via Save/Delete while ListDevices, Get and GetByPublicKey iterate it. The metadata sync goroutine, which is enabled by default, adds a further writer every 30s.

The concurrent map access is a fatal Go runtime error rather than a recoverable panic, so RecoveryMiddleware cannot contain it and the whole process aborts, dropping every client's tunnel along with the web UI.

This only affects the memory:// backend, which is the default when running the binary directly. The container image is unaffected with its sqlite backend which hold no shared in-process state and are unaffected.

Add a sync.RWMutex: write-lock Save and Delete, read-lock the readers. Save and Delete release the lock before emitting watcher events so that callbacks which read back from storage cannot deadlock. GetByPublicKey iterates via an unlocked internal helper under a single RLock to avoid recursive locking.

The added test reproduces the crash reliably without needing -race, so it guards the fix under the existing CI configuration.