### PR TITLE
fix: force LF for shell scripts via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Force LF for shell scripts regardless of the checking-out user's
+# core.autocrlf setting. Shell scripts run inside Linux build/CI stages
+# (see buildinfo/get_version.sh, invoked from Dockerfile) and a CRLF
+# checkout breaks their shebang line with a cryptic
+# "syntax error: unexpected end of file" from /bin/sh.
+*.sh text eol=lf


### PR DESCRIPTION
Shell scripts (ex. `buildinfo/get_version.sh` etc.) are invoked inside the Linux build stage of the Dockerfile. 
On a fresh checkout with `core.autocrlf=true` (the common Windows Git default), these get CRLF line endings.

This ultimately breaks build process entirely since the shebang has wrong line endings, causing it to output a cryptic 
`"syntax error: unexpected end of file"` from /bin/sh - a pain in the *** for me building Dockerfile on Windows.

The committed blobs were already LF-only; this only affects checkout, so no content renormalization was needed.

Disclosure: analyzed and committed by Claude under strict dev supervision)